### PR TITLE
Bugfix #1: Implement stack pointer synchronization detection

### DIFF
--- a/src/dyclient/count.cpp
+++ b/src/dyclient/count.cpp
@@ -1328,6 +1328,16 @@ static void at_return(app_pc targ_addr) {
 
 #else // ! ifdef ADDR_CONV
 void stackoverflow_exit() {
+    PRINTF_STDERR("Error: Stack overflow, stack contents:\n");
+    int i;
+    for (i = 0; i < stack_index; i++) {
+        address addr = app_pc_to_address(call_stack[i].return_addr);
+        PRINTF_STDERR("%10x [%s]\n", addr.second, modules.at(addr.first).path.c_str());
+        if (i == 20 && stack_index - 20 > i) {
+            i = stack_index - 21;
+            PRINTF_STDERR("   ...\n", addr.second, modules.at(addr.first).path.c_str());
+        }
+    }
     PRINT_STDERR("Error: overflow occurs when doing stack profiling! Please use a larger value for --stack-size.\n");
     dr_abort();
 }


### PR DESCRIPTION
This pull request aims to implicitly detect `longjmp` and exceptions in profiled programs to more accurately profile them and fix #1.

To do this, I extended the `call_stack` data structure in `src/dyclient/count.cpp` to also track the stack pointer at each call site and return. At each function return, the application's stack pointer is compared against the value we expect based on the corresponding call instruction. In the event that these do not match, we infer the presence of some strange control flow such as a `longjmp` or exception, and search our record of the stack to see if any call has a matching value for the stack pointer. If we can find such a call site, we assume that this return corresponds to that call, and unwind an appropriate amount of stack frames. If we cannot find a corresponding call site, we output a warning and carry on as normal, in the hopes it will resynchronise later.