### PR TITLE
Search for mmap range to avoid rounding bug

### DIFF
--- a/src/analyzer/support.hpp
+++ b/src/analyzer/support.hpp
@@ -17,7 +17,7 @@ using namespace std;
 
 struct app_module {
     string path;
-    map<uint64_t, uint64_t> file_offset_to_vaddr;
+    map<uint64_t, pair<uint64_t, uint64_t>> file_offset_to_vaddr;
 };
 
 typedef vector<app_module>::size_type app_module_id;


### PR DESCRIPTION
When looking for the program header entry corresponding to a given `mmap `call, the analysis program could find the wrong mapping due to the fact that `mmap` calls may in practice be rounded by the loader.  For example, if an ELF file requests a length `0x20` mapping of offset 0x10400, the loader may instead make a `0x1000` byte mapping of offset `0x10000` as this covers the requested range.  This patch causes the analyzer to search for a program header line that might correspond to the `mmap`, taking into account the length.  This could still fail in principle because for example multiple small entries may all be valid, in which case a warning will be printed.