### PR TITLE
Bugfixes for Aarch64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,8 +82,8 @@ $(INSTALL_DIR)/share/optiwise/bin/%: scripts/share/optiwise/bin/% | $(INSTALL_DI
 
 $(BUILD_DIR)/dyclient/Makefile: src/dyclient/CMakeLists.txt | $(BUILD_DIR)/dyclient $(DYNAMORIO_DIRNAME)/bin64/drrun
 	cd $(BUILD_DIR)/dyclient; cmake -DDynamoRIO_DIR=../../$(DYNAMORIO_DIRNAME)/cmake ../../src/dyclient
-$(BUILD_DIR)/dyclient/bin/liboptiwise.so $(BUILD_DIR)/dyclient/bin/libexit0.so: $(BUILD_DIR)/dyclient/Makefile src/dyclient/*.cpp
-	$(MAKE) -C $(BUILD_DIR)/dyclient
+$(BUILD_DIR)/dyclient/bin/lib%.so: $(BUILD_DIR)/dyclient/Makefile src/dyclient/*.cpp
+	$(MAKE) -C $(BUILD_DIR)/dyclient $*
 $(INSTALL_DIR)/share/optiwise/lib/%.so: $(BUILD_DIR)/dyclient/bin/%.so | $(INSTALL_DIR)/share/optiwise/lib
 	cp $< $@
 


### PR DESCRIPTION
After running some benchmarks on AArch64 some issues were identified fixed by these three commits.

* A lot of symbol names like `.hidden main` were encountered, which is a mistake in the way we parse objdump symbol tables. `.hidden` is an attribute so should not be part of the symbol name.
* Invalid control flow graphs could be generated in the DynamoRIO client with `0:???` addresses. This happened specifically in the case of indirect branches that triggered the `missed_mbr` logic and also the `JUMP_MBR` optimisation.
* A second DynamoRIO client problem existed because a fix for x86 mbrs was not available on Aarch64. Now both architectures get the same treatment.
* A minor bug in the Makefile was leading to the DynamoRIO client being built twice, which potentially interfered with parallel make.