### PR TITLE
Detect function nesting information.

### DIFF
--- a/src/analyzer/loop_fetcher.hpp
+++ b/src/analyzer/loop_fetcher.hpp
@@ -3,6 +3,6 @@
 
 #include "support.hpp"
 
-int extract_loops(const dycfg& cfg, const address &entry, list<loop>& all_loops);
+void extract_loops_and_nesting(dycfg& cfg, const address &entry, list<loop>& all_loops);
 
 #endif


### PR DESCRIPTION
This patch means that for each function we compute the call site and function that dominates this call in the CFG with returns removed. Hence in particular we know that if a sample occurs in a particular function, all the dominating functions must be on the stack, and so we can detect missing stack frames in the perf output. This addresses issue #2 as best as reasonably possible, without better output from perf.

This patch will also support future output of the program structure.