### PR TITLE
Add 'optiwise gui' command.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ install_dir*/
 DynamoRIO-*/
 optiwise_result/
 tests/bin*/
+__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,9 @@ DYNAMORIO_URL ?= https://github.com/DynamoRIO/dynamorio/releases/download/releas
 SRC_SCRIPTS := scripts/bin/optiwise $(wildcard scripts/share/optiwise/bin/*)
 INSTALL_SCRIPTS := $(patsubst scripts%,$(INSTALL_DIR)%,$(SRC_SCRIPTS))
 INSTALL_LIBS := $(addprefix $(INSTALL_DIR)/share/optiwise/lib/,liboptiwise.so libexit0.so)
+INSTALL_PYTHON := $(patsubst src/gui/%,$(INSTALL_DIR)/share/optiwise/lib/gui/%,$(wildcard src/gui/*.py))
 
-all: $(INSTALL_SCRIPTS) $(INSTALL_LIBS) $(INSTALL_DIR)/share/optiwise/dynamorio \
+all: $(INSTALL_SCRIPTS) $(INSTALL_LIBS) $(INSTALL_PYTHON) $(INSTALL_DIR)/share/optiwise/dynamorio \
 	$(INSTALL_DIR)/share/optiwise/bin/analyzer \
 	$(INSTALL_DIR)/share/optiwise/bin/analyzer-serial
 .PHONY: all
@@ -99,6 +100,11 @@ $(INSTALL_DIR)/share/optiwise/bin/analyzer-serial: $(BUILD_DIR)/analyzer-serial 
 	cp $< $@
 
 ###############################################################################
+# Gui copy
+$(INSTALL_DIR)/share/optiwise/lib/gui/%.py: src/gui/%.py | $(INSTALL_DIR)/share/optiwise/lib/gui
+	cp $< $@
+
+###############################################################################
 # Directory structure rules
 
 # Rules to make target directory structure
@@ -117,4 +123,6 @@ $(INSTALL_DIR)/share/optiwise: | $(INSTALL_DIR)/share
 $(INSTALL_DIR)/share/optiwise/bin: | $(INSTALL_DIR)/share/optiwise
 	[ -d "$@" ] || mkdir "$@"
 $(INSTALL_DIR)/share/optiwise/lib: | $(INSTALL_DIR)/share/optiwise
+	[ -d "$@" ] || mkdir "$@"
+$(INSTALL_DIR)/share/optiwise/lib/gui: | $(INSTALL_DIR)/share/optiwise/lib
 	[ -d "$@" ] || mkdir "$@"

--- a/scripts/bin/optiwise
+++ b/scripts/bin/optiwise
@@ -108,6 +108,8 @@ Supported commands:
   count        Obtain execution count for program's execution.
   analyze      Analyze and combine output of 'sample', 'disassemble', and
                'count'.
+  gui          Generate an HTML/JavaScript GUI for viewing the output of
+               'analyze' as a series of static html pages.
 
 By default results and temporary files will go in the 'optiwise_result'
 directory within the working directory.  The output of each subcommand generally

--- a/scripts/share/optiwise/bin/optiwise-analyze
+++ b/scripts/share/optiwise/bin/optiwise-analyze
@@ -241,7 +241,7 @@ if [ "${flag_verbose-}" ]; then
     "$result_dir/count/$name_count" \
     "$result_dir/analyze/$name_analyze/inst.csv" \
     "$result_dir/analyze/$name_analyze/loop.csv" \
-    "$result_dir/analyze/$name_analyze/structure.txt" \
+    "$result_dir/analyze/$name_analyze/structure.yaml" \
   '4<('$zcat "$result_dir/disassemble/$name_disassemble"')'
 fi
 perf script \
@@ -253,6 +253,6 @@ perf script \
   "$result_dir/count/$name_count" \
   "$result_dir/analyze/$name_analyze/inst.csv" \
   "$result_dir/analyze/$name_analyze/loop.csv" \
-  "$result_dir/analyze/$name_analyze/structure.txt" 4<<EOF
+  "$result_dir/analyze/$name_analyze/structure.yaml" 4<<EOF
 $($zcat "$result_dir/disassemble/$name_disassemble")
 EOF

--- a/scripts/share/optiwise/bin/optiwise-check
+++ b/scripts/share/optiwise/bin/optiwise-check
@@ -27,7 +27,9 @@ Options:
    --no-quiet
   -d, --result-dir=<directory>
                Override the result directory.
-  -E, --objdump Override the name of the 'objdump' utility.
+  -g, --gui    Check if 'optiwise gui' is likely to succeed.
+  -E, --objdump=<binary>
+               Override the path/name of the 'objdump' utility.
 EOF
       exit 0
       ;;
@@ -36,6 +38,7 @@ EOF
     -v|--verbose) unset flag_quiet;;
     -d|--result-dir) shift; result_dir=$1;;
     --result-dir=*) result_dir=${1#--*=};;
+    -g|--gui) flag_gui="$1";;
     -E|--objdump) shift; objdump="$1";;
     --objdump=*) objdump="${1#--*=}";;
     --) shift; break;;
@@ -428,6 +431,65 @@ Error: It is not be possible to create or write the '$result_dir' directory.
 
        Try specifiying a different result directory (--result-dir=DIRECTORY).
 EOF
+fi
+
+if [ "${flag_gui-}" ]; then
+  if [ -z "$(which python3)" ]; then
+    if grep -q -s "[Dd]ebian" /etc/os-release; then
+      python3_install_suggest=", perhaps via 'sudo apt install python3 python3-graphviz'"
+    else
+      python3_install_suggest=" from your package manager"
+    fi
+    cat >&2 <<EOF
+Error: python3 executable not found.
+
+       Try installing python3$python3_install_suggest.
+EOF
+    any_error=1
+  elif ! python3 -c 'import graphviz' > /dev/null 2> /dev/null; then
+    if grep -q -s "[Dd]ebian" /etc/os-release; then
+      python_graphviz_install_suggest=", perhaps via 'sudo apt install python3-graphviz'"
+    else
+      python_graphviz_install_suggest=" from your package manager"
+    fi
+    cat >&2 <<EOF
+Error: python3 -c 'import graphviz' failed.
+
+       Try installing python graphviz$python_graphviz_install_suggest.
+EOF
+    any_error=1
+  fi
+
+  if [ -z "$(which c++filt)" ]; then
+    if grep -q -s "[Dd]ebian" /etc/os-release; then
+      cxxfilt_install_suggest=", perhaps via 'sudo apt install binutils'"
+    else
+      cxxfilt_install_suggest=" from your package manager"
+    fi
+    cat >&2 <<EOF
+Warning: c++filt executable not found. This means the 'optiwise gui' will not
+         be able to provide demangled symbol names, so you may see function
+         names like '_Z3addii' instead of 'add(int, int)'.
+
+         Try installing c++filt$cxxfilt_install_suggest.
+EOF
+    any_warning=1
+  fi
+
+  if [ ! -x /usr/bin/ex ]; then
+    if grep -q -s "[Dd]ebian" /etc/os-release; then
+      ex_install_suggest=", perhaps via 'sudo apt install vim'"
+    else
+      ex_install_suggest=" from your package manager"
+    fi
+    cat >&2 <<EOF
+Warning: /usr/bin/ex executable not found. This means the 'optiwise gui' will
+         not be able to provide syntax highlighting.
+
+         Try installing ex (or vim)$ex_install_suggest.
+EOF
+    any_warning=1
+  fi
 fi
 
 if [ -z "${any_error+1}" -a -z "${any_warning+1}" -a -z "${flag_quiet+1}" ]; then

--- a/scripts/share/optiwise/bin/optiwise-gui
+++ b/scripts/share/optiwise/bin/optiwise-gui
@@ -1,0 +1,192 @@
+#!/bin/sh -u
+#
+# Script to gui and combine the output of sampling and execution counting.
+
+share_bin_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+share_dir="$(realpath "$share_bin_dir/..")"
+result_dir=optiwise_result
+
+while :; do
+  case "${1-}" in
+    -h|--help)
+      cat <<EOF
+Usage: optiwise gui [<options>]
+Generate an HTML and Javascript based interface for viewing the output of
+'optiwise analyze' and 'optiwise count' to HTML form.  Automatically opens the
+web browser if possible.
+
+Options:
+  -h, --help   Display this help.
+  -v, --verbose
+               Be more verbose in operation.
+  -d, --result-dir=<directory>
+               Override the result directory.
+  --no-browser Do not automatically start a web browser.
+  -n, --name   Sets all of the --name-* variables. Can be used to easily store
+               many separate profiling runs.
+  --name-gui   Name of the output directory to render to. Should be a valid
+               filename (not a path) (default: result).
+  --name-analyze
+               Name of the analyze output directory to render (default: most
+               recent).
+  --name-count Name of the execution counting run to render (default: most
+               recent).
+EOF
+      exit 0
+      ;;
+    -v|--verbose) flag_verbose="$1";;
+    -d|--result-dir) shift; result_dir=$1;;
+    --result-dir=*) result_dir=${1#--*=};;
+    --no-browser) flag_browser="$1";;
+    -n|--name) shift; name="$1";;
+    --name=*) name="${1#--*=}";;
+    --name-gui) shift; name_gui="$1";;
+    --name-gui=*) name_gui="${1#--*=}";;
+    --name-analyze) shift; name_analyze="$1";;
+    --name-analyze=*) name_analyze="${1#--*=}";;
+    --name-count) shift; name_count="$1";;
+    --name-count=*) name_count="${1#--*=}";;
+    --) shift; break;;
+    -?*)
+      cat >&2 <<EOF
+Unrecognized option '$1'
+Try '--help'
+EOF
+      exit 1
+      ;;
+    *) break;;
+  esac
+  shift
+done
+
+if [ "${1-}" ]; then
+  cat >&2 <<EOF
+Error: Unnecessary positional arguments detected e.g. '$1'.
+
+'optiwise gui' does not take any positional arguments, such as the name of the
+program to disassemble. In other words, use 'optiwise gui' not 'optiwise gui
+/bin/echo' or anything similar.
+
+See 'optiwise gui --help' for more information.
+EOF
+  exit 1
+fi
+
+if [ ! "${name_count-}" ]; then
+  if [ "${name-}" ]; then
+    name_count="$name.txt"
+  elif [ -d "$result_dir" -a -d "$result_dir/count" ] ; then
+    # Loop to find newest file in the directory
+    for f in "$result_dir/count/"*; do
+      if [ -f "$f" ]; then
+        if
+          [ ! "${name_count-}" ] || \
+          [ "$f" -nt "$result_dir/count/$name_count" ]
+        then
+          name_count="${f#"$result_dir/count/"}"
+        fi
+      fi
+    done
+    if [ ! -f "$result_dir/count/${name_count-}" ]; then
+      cat >&2 <<EOF
+Error: No execution count runs found in result directory: '$result_dir/count'.
+
+Have you run 'optiwise count' yet? The gui requires an execution count first.
+
+See 'optiwise gui --help' for more information.
+EOF
+      exit 1
+    fi
+  fi
+fi
+if [ ! -f "$result_dir/count/$name_count" ]; then
+  cat >&2 <<EOF
+Error: Execution count run not found: '$result_dir/count/$name_count'.
+
+Have you run 'optiwise count' yet? The gui requires an execution count first.
+
+See 'optiwise gui --help' for more information.
+EOF
+  exit 1
+fi
+
+if [ ! "${name_analyze-}" ]; then
+  if [ "${name-}" ]; then
+    name_analyze="$name"
+  elif [ -d "$result_dir" -a -d "$result_dir/analyze" ] ; then
+    # Loop to find newest file in the directory
+    for f in "$result_dir/analyze/"*; do
+      if [ -f "$f/structure.yaml" ]; then
+        if
+          [ ! "${name_analyze-}" ] || \
+          [ "$f/structure.yaml" -nt "$result_dir/analyze/$name_analyze/structure.yaml" ]
+        then
+          name_analyze="${f#"$result_dir/analyze/"}"
+        fi
+      fi
+    done
+    if [ ! -f "$result_dir/analyze/${name_analyze-}/structure.yaml" ]; then
+      cat >&2 <<EOF
+Error: No analyze output found in result directory: '$result_dir/analyze'.
+
+Have you run 'optiwise analyze' yet? The gui requires analysis first.
+
+See 'optiwise gui --help' for more information.
+EOF
+      exit 1
+    fi
+  fi
+fi
+if [ ! -f "$result_dir/analyze/${name_analyze-}/structure.yaml" ]; then
+  cat >&2 <<EOF
+Error: No analyze output found in result directory: '$result_dir/analyze/${name_analyze-}'.
+
+Have you run 'optiwise analyze' yet? The gui requires analysis first.
+
+See 'optiwise gui --help' for more information.
+EOF
+  exit 1
+fi
+
+if [ ! "${name_gui-}" ]; then
+  if [ "${name-}" ]; then
+    name_gui="$name"
+  else
+    name_gui=result
+  fi
+fi
+
+if [ ! -d "$result_dir/gui" ]; then
+  if [ "${flag_verbose-}" ]; then
+    printf "Creating directory '%s'\n" "$result_dir/gui"
+  fi
+  mkdir -p "$result_dir/gui" || exit $?
+fi
+if [ ! -d "$result_dir/gui/$name_gui" ]; then
+  if [ "${flag_verbose-}" ]; then
+    printf "Creating directory '%s'\n" "$result_dir/gui/$name_gui"
+  fi
+  mkdir -p "$result_dir/gui/$name_gui" || exit $?
+fi
+
+if [ ! "${flag_browser-}" ] && [ "${DISPLAY-}" ]; then
+  if [ "${flag_verbose-}" ]; then
+    echo python3 $share_dir/lib/gui/gui.py "$result_dir/count/$name_count" \
+      "$result_dir/analyze/$name_analyze" \
+      "$result_dir/gui/$name_gui" \
+    '&&' gnome-www-browser "$result_dir/gui/$name_gui/index.html"
+  fi
+  python3 $share_dir/lib/gui/gui.py "$result_dir/count/$name_count" \
+    "$result_dir/analyze/$name_analyze" \
+    "$result_dir/gui/$name_gui" \
+  && gnome-www-browser "$result_dir/gui/$name_gui/index.html"
+else
+  if [ "${flag_verbose-}" ]; then
+    echo python3 $share_dir/lib/gui/gui.py "$result_dir/count/$name_count" \
+      "$result_dir/analyze/$name_analyze" \
+      "$result_dir/gui/$name_gui"
+  fi
+  exec python3 $share_dir/lib/gui/gui.py "$result_dir/count/$name_count" \
+    "$result_dir/analyze/$name_analyze" \
+    "$result_dir/gui/$name_gui"
+fi

--- a/scripts/share/optiwise/bin/optiwise-run
+++ b/scripts/share/optiwise/bin/optiwise-run
@@ -13,7 +13,8 @@ while :; do
 Usage: optiwise run [<options>] [--] <program> [<arguments>]
 All-in-one profiling command. Roughly equivalent to 'optitwise check' then
 'optiwise sample' then 'optiwise disassemble' then 'optiwise count' then
-'optiwise analyze'. A good starting point for beginners.
+'optiwise analyze'. A good starting point for beginners. Pass --gui to also run
+'optiwise gui'.
 
 Some options to specific commands cannot be passed in this form, if more fine
 control is needed then run the commands individually.
@@ -25,6 +26,8 @@ Options:
                 Override the result directory (default: $result_dir).
   -n, --name    Specifies a name for output of this sampling run. Should be a
                 valid filename (not a path) (default: $name).
+  -g, --gui     Additionally, run 'optiwise gui' to generate a HTML/JavaScript
+                interface for viewing the output.
   -f, --frequency
                 Sets sampling frequency to specified value in Hz.
   -E, --objdump Override the name of the 'objdump' utility.
@@ -39,6 +42,7 @@ EOF
     --result-dir=*) result_dir="${1#--*=}";;
     -n|--name) shift; name="$1";;
     --name=*) name="${1#--*=}";;
+    -g|--gui) flag_gui="$1";;
     -f|--frequency) shift; frequency="--frequency=$1";;
     --frequency=*) frequency="--frequency=${1#--*=}";;
     -E|--objdump) shift; objdump="--objdump=$1";;
@@ -88,10 +92,10 @@ if [ ! -d "$result_dir" ]; then
 fi
 
 if [ "${flag_verbose-}" ]; then
-  echo "$share_bin_dir/optiwise-check" ${flag_verbose-} ${objdump-} -- "$@"
+  echo "$share_bin_dir/optiwise-check" ${flag_verbose-} ${objdump-} ${flag_gui-} -- "$@"
 fi
 
-"$share_bin_dir/optiwise-check" ${flag_verbose-} ${objdump-} -- "$@" || exit $?
+"$share_bin_dir/optiwise-check" ${flag_verbose-} ${objdump-} ${flag_gui-} -- "$@" || exit $?
 
 if [ "${flag_verbose-}" ]; then
   echo "$share_bin_dir/optiwise-sample" \
@@ -130,5 +134,12 @@ if [ "${flag_verbose-}" ]; then
     ${flag_verbose-} --name="$name"
 fi
 
-exec "$share_bin_dir/optiwise-analyze" \
-  ${flag_verbose-} --name="$name"
+if [ "${flag_gui-}" ]; then
+  if [ "${flag_verbose-}" ]; then
+    echo "$share_bin_dir/optiwise-gui" \
+      ${flag_verbose-} --name="$name"
+  fi
+
+  exec "$share_bin_dir/optiwise-gui" \
+    ${flag_verbose-} --name="$name"
+fi

--- a/src/analyzer/io.hpp
+++ b/src/analyzer/io.hpp
@@ -31,6 +31,16 @@ void write_exe_count(
         const dycfg &cfg,
         inst_table& profiling_result,
         const objdump_table& objdump_result);
-void write_loop(string loops_csv_path, string loop_body_path, list<loop> &all_loops, dycfg &cfg, inst_table& profiling_result);
+void write_loop(
+        const string &loops_csv_path,
+        const list<loop> &all_loops,
+        const dycfg &cfg,
+        const inst_table& profiling_result);
+void write_structure(
+        const string &path,
+        const list<loop> &all_loops,
+        const func_table &functions,
+        const dycfg &cfg,
+        const inst_table &profiling_result);
 
 #endif /* ifndef IO_HPP_ */

--- a/src/gui/gui.py
+++ b/src/gui/gui.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+import sys
+
+try:
+    import graphviz
+except ImportError as e:
+    print(
+"Error: Python 'import graphviz' failed: " + str(e) + "\n"
+"       Install python graphviz, perhaps via 'apt install python3-graphviz', to\n"
+"       use OptiWISE gui.",
+    file=sys.stderr)
+    sys.exit(1)
+
+import processor
+import render
+
+path_count = sys.argv[1]
+path_analyze = sys.argv[2]
+path_gui = sys.argv[3]
+try:
+    file_count = open(path_count)
+    file_inst_csv = open(path_analyze + '/inst.csv')
+    file_loop_csv = open(path_analyze + '/loop.csv')
+    file_structure = open(path_analyze + '/structure.yaml')
+except OSError as e:
+    print("Error: count not open input: " + str(e), file=sys.stderr)
+    sys.exit(1)
+
+try:
+    with file_count as a, file_inst_csv as b, file_loop_csv as c, file_structure as d:
+        p = processor.Processed(a, b, c, d)
+except Exception as e:
+    print("Error: count not read or process input: " + str(e), file=sys.stderr)
+    sys.exit(1)
+
+output = path_gui + '/'
+r = render.Renderer(p)
+
+exit_code = 0
+
+def open_output(path):
+    try:
+        return open(output + path, 'w')
+    except OSError as e:
+        print("Error: count not open output : " + str(e), file=sys.stderr)
+        exit_code = 1
+        return None
+
+for function in p.functions.values():
+    function.do_render = function.samples_inc > 0
+try:
+    file_index = open_output('index.html')
+    if file_index is not None:
+        with file_index as f:
+            print("Info: output index.html")
+            f.write(r.render_functions())
+except Exception as e:
+    print("Error: count not write output: " + str(e), file=sys.stderr)
+    exit_code = 1
+for function in p.functions.values():
+    if function.do_render:
+        func_filename = r.function_filename(function)
+        try:
+            file_func = open_output(func_filename)
+            if file_func is not None:
+                with file_func as f:
+                    print("Info: output", func_filename)
+                    f.write(r.render_function(function))
+        except Exception as e:
+            print("Error: count not write output: " + str(e), file=sys.stderr)
+            exit_code = 1
+
+sys.exit(exit_code)

--- a/src/gui/parser.py
+++ b/src/gui/parser.py
@@ -1,0 +1,304 @@
+# Module to parse the output of prof and the dynamoRio client
+import csv
+import yaml
+
+class ControlFlowGraph:
+    class Module:
+        def __init__(self, line='Module 0 (null)'):
+            # e.g. 'Module 2 /path/to/file'
+            # e.g. 'Module 5 [vdso]'
+            fields = line.split(' ', 2)
+            self.index = int(fields[1])
+            self.path = fields[2]
+            self.nodes = dict()
+        def __str__(self):
+            return ' '.join([
+                'Module',
+                str(self.index),
+                self.path,
+            ])
+
+    class Node:
+        def __init__(self, modules, lines):
+            line = next(lines)
+            # e.g. '2:2000 1 0 jz'
+            fields = line.split(' ', 3)
+            subfields = fields[0].split(':', 1)
+            module = int(subfields[0])
+            offset = int(subfields[1], 16)
+            self.module = modules[module]
+            self.module.nodes[offset] = self
+            self.first = offset
+            self.size = 0
+            self.count = int(fields[1])
+            self.callee_count = int(fields[2])
+            self.children = []
+            self.parents = dict()
+            for line in lines:
+                # e.g. '	+12 2'
+                # e.g. '	2:2016 1'
+                if line.startswith('\t+'):
+                    fields = line[2:].split(' ', 1)
+                    offset = int(fields[0], 16)
+                    length = int(fields[1])
+                    end = offset + length
+                    self.size = max(self.size, end)
+                else:
+                    fields = line[1:].split(' ', 1)
+                    subfields = fields[0].split(':',1)
+                    module = int(subfields[0])
+                    address = int(subfields[1], 16)
+                    count = int(fields[1])
+                    self.children.append((modules[module], address, count))
+
+        def __str__(self):
+            return ' '.join([
+                'M' + str(self.module.index),
+                hex(self.first)[2:],
+                hex(self.last)[2:],
+                str(self.size),
+                str(self.count),
+                str(self.callee_count),
+            ])
+
+    def __init__(self, input_file):
+        # Parsng
+        modules = dict()
+        node_lines = []
+        self.entries = []
+        for line in input_file:
+            if line.startswith("#"): continue
+            if len(line) < 2: continue
+            if line[-1] == '\n': line = line[:-1]
+            if line[0] != '\t' and len(node_lines) > 0:
+                node = ControlFlowGraph.Node(modules, iter(node_lines))
+                node_lines = []
+            if line.startswith('Architecture '):
+                self.architecture = line[len('Architecture '):]
+                continue
+            elif line.startswith('Module'):
+                module = ControlFlowGraph.Module(line)
+                modules[module.index] = module
+                continue
+            elif line.startswith('Entry'):
+                # e.g. 'Entry 3:1100 1'
+                fields = line.split(' ', 2)
+                count = int(fields[2])
+                fields = fields[1].split(':', 1)
+                module = int(fields[0])
+                offset = int(fields[1], 16)
+                entry = {'module': module, 'offset': offset, 'count': count}
+                self.entries.append(entry)
+                continue
+            node_lines.append(line)
+        if len(node_lines) > 0:
+            node = ControlFlowGraph.Node(modules, iter(node_lines))
+
+        # Post processing
+        self.modules = dict()
+        for module in modules.values():
+            self.modules[module.path] = module
+            for node in module.nodes.values():
+                children = node.children
+                node.children = dict()
+                for cmodule, cfirst, count in children:
+                    cnode = cmodule.nodes[cfirst]
+                    node.children[cnode] = count
+                    cnode.parents[node] = count
+
+
+class InstructionsCsv:
+    class Instruction:
+        def __init__(self, row):
+            self.module = row['path']
+            self.address = int(row['inst_addr_hex'][2:],16)
+            self.samples = int(row['samples'])
+            self.count = int(row['execution_count'])
+            self.cycles = int(row['cpu_cycle'])
+            self.asm = row['disassembly']
+            self.function = row['func_name']
+            self.inlined = row['inlined_func']
+            self.line = row['line']
+        def __str__(self):
+            return ','.join([
+                '"' + self.module + '"',
+                hex(self.address),
+                str(self.samples),
+                str(self.count),
+                str(self.cycles),
+                '"' + self.asm + '"',
+                '"' + self.function + '"',
+                '"' + self.inlined + '"',
+                '"' + self.line + '"',
+            ])
+    def __init__(self, input_file):
+        reader = csv.DictReader(input_file)
+        self.instructions = dict()
+        for row in reader:
+            instr = InstructionsCsv.Instruction(row)
+            if instr.module not in self.instructions:
+                self.instructions[instr.module] = dict()
+            self.instructions[instr.module][instr.address] = instr
+
+class LoopsCsv:
+    class Loop:
+        def __init__(self, row):
+            self.module = row['file']
+            self.head = int(row['head_addr'][2:],16)
+            self.tail = int(row['tail_addr'][2:],16)
+            self.iterations = int(row['iters'])
+            self.invocations = int(row['invocs'])
+            self.samples = int(row['samples'])
+            self.count = int(row['insts'])
+            self.cycles = int(row['cycles'])
+            self.coverage = float(row['cover'])
+            self.function = row['loop_func']
+            self.lines = row['source']
+        def __str__(self):
+            return ','.join([
+                '"' + self.module + '"',
+                hex(self.head),
+                hex(self.tail),
+                str(self.iterations),
+                str(self.invocations),
+                str(self.samples),
+                str(self.count),
+                str(self.cycles),
+                str(self.coverage),
+                '"' + self.function + '"',
+                '"' + self.lines + '"',
+            ])
+    def __init__(self, input_file):
+        reader = csv.DictReader(input_file)
+        self.loops = dict()
+        for row in reader:
+            loop = LoopsCsv.Loop(row)
+            if loop.module not in self.loops:
+                self.loops[loop.module] = dict()
+                self.loops[loop.module][(loop.head,loop.tail)] = loop
+
+class ProgramStructure:
+    class Module:
+        def __init__(self, yaml):
+            self.index = int(yaml['module'])
+            self.path = str(yaml['path'])
+            self.loops = []
+            self.functions = dict()
+        def __str__(self):
+            return ' '.join([
+                'Module',
+                str(self.index),
+                self.path,
+            ])
+
+    class Loop:
+        def __init__(self, modules, function, module, yaml):
+            self.module = module
+            self.function = function
+            module.loops.append(self)
+            self.offset = yaml['loop']
+            self.invocations = yaml['invocations']
+            self.iterations = yaml['stats']['iterations']
+            self.iter_per_invoc = yaml['stats']['iter-per-invoc']
+            self.backedges = yaml['back-edges']
+            self.blocks_inclusive = yaml['blocks-inclusive']
+            self.blocks_exclusive = yaml['blocks-exclusive']
+            self.callees = yaml['callees']
+            if 'stats-inclusive' in yaml and 'cover' in yaml['stats-inclusive']:
+                self.cover = yaml['stats-inclusive']['cover']
+            elif 'stats-exclusive' in yaml and 'cover' in yaml['stats-exclusive']:
+                self.cover = yaml['stats-exclusive']['cover']
+            else: self.cover = 0
+            if 'stats-inclusive' in yaml and 'cycles' in yaml['stats-inclusive']:
+                self.cycles = yaml['stats-inclusive']['cycles']
+            elif 'stats-exclusive' in yaml and 'cycles' in yaml['stats-exclusive']:
+                self.cycles = yaml['stats-exclusive']['cycles']
+            else: self.cycles = 0
+            if 'stats-inclusive' in yaml and 'ipc' in yaml['stats-inclusive']:
+                self.ipc = yaml['stats-inclusive']['ipc']
+            elif 'stats-exclusive' in yaml and 'ipc' in yaml['stats-exclusive']:
+                self.ipc = yaml['stats-exclusive']['ipc']
+            else: self.ipc = 0
+            if 'stats-inclusive' in yaml and 'inst-per-iter' in yaml['stats-inclusive']:
+                self.inst_per_iter = yaml['stats-inclusive']['inst-per-iter']
+            elif 'stats-exclusive' in yaml and 'inst-per-iter' in yaml['stats-exclusive']:
+                self.inst_per_iter = yaml['stats-exclusive']['inst-per-iter']
+            else: self.inst_per_iter = 0
+            self.nodes = []
+            if 'nodes' not in yaml: return
+            for node in yaml['nodes']:
+                if 'function' in node:
+                    self.nodes.append(ProgramStructure.Function(modules, node))
+                elif 'loop' in node:
+                    self.nodes.append(ProgramStructure.Loop(modules, function, module, node))
+                else:
+                    raise RuntimeError("parse error")
+        def resolve_callees(self, modules):
+            self.callees = list(map(lambda x: modules[x['module']].functions[x['offset']], self.callees))
+            for node in self.nodes: node.resolve_callees(modules)
+
+    class Function:
+        def __init__(self, modules, yaml):
+            self.name = yaml['function']
+            self.module = modules[int(yaml['address']['module'])]
+            self.offset = yaml['address']['offset']
+            self.invocations = yaml['invocations']
+            self.blocks_exclusive = yaml['blocks-exclusive']
+            if 'stats-inclusive' in yaml and 'cover' in yaml['stats-inclusive']:
+                self.cover = yaml['stats-inclusive']['cover']
+            elif 'stats-exclusive' in yaml and 'cover' in yaml['stats-exclusive']:
+                self.cover = yaml['stats-inclusive']['cover']
+            else: self.cover = 0
+            if 'stats-inclusive' in yaml and 'cycles' in yaml['stats-inclusive']:
+                self.cycles = yaml['stats-inclusive']['cycles']
+            elif 'stats-exclusive' in yaml and 'cycles' in yaml['stats-exclusive']:
+                self.cycles = yaml['stats-exclusive']['cycles']
+            else: self.cycles = 0
+            if 'stats-inclusive' in yaml and 'ipc' in yaml['stats-inclusive']:
+                self.ipc = yaml['stats-inclusive']['ipc']
+            elif 'stats-exclusive' in yaml and 'ipc' in yaml['stats-exclusive']:
+                self.ipc = yaml['stats-exclusive']['ipc']
+            else: self.ipc = 0
+            if 'stats-inclusive' in yaml and 'samples' in yaml['stats-inclusive']:
+                self.samples = yaml['stats-inclusive']['samples']
+            elif 'stats-exclusive' in yaml and 'samples' in yaml['stats-exclusive']:
+                self.samples = yaml['stats-exclusive']['samples']
+            else: self.samples = 0
+            self.module.functions[self.offset] = self
+            self.length = yaml['address']['length']
+            self.nodes = []
+            self.callees = yaml['callees']
+            self.callsites = dict()
+            for caller in yaml['callers']:
+                module = modules[caller['function']['module']]
+                for site in caller['sites']:
+                    self.callsites[(module, site['offset'])] = (caller['function']['offset'], site['count'])
+            if 'nodes' not in yaml: return
+            for node in yaml['nodes']:
+                if 'function' in node:
+                    self.nodes.append(ProgramStructure.Function(modules, node))
+                elif 'loop' in node:
+                    self.nodes.append(ProgramStructure.Loop(modules, self, self.module, node))
+                else:
+                    raise RuntimeError("parse error")
+        def resolve_callees(self, modules):
+            self.callees = list(map(lambda x: modules[x['module']].functions[x['offset']], self.callees))
+            for node in self.nodes: node.resolve_callees(modules)
+
+    def __init__(self, input_file):
+        content = yaml.safe_load(input_file.read())
+        modules = dict()
+        for m in content['modules']:
+            module = ProgramStructure.Module(m)
+            modules[module.index] = module
+        self.nodes = []
+        for node in content['nodes']:
+            if 'function' in node:
+                self.nodes.append(ProgramStructure.Function(modules, node))
+            else:
+                raise RuntimeError("parse error")
+        for node in self.nodes:
+            node.resolve_callees(modules)
+        self.modules = dict()
+        for module in modules.values():
+            self.modules[module.path] = module

--- a/src/gui/processor.py
+++ b/src/gui/processor.py
@@ -1,0 +1,399 @@
+from parser import *
+import pathlib
+import subprocess
+import sys
+
+class Instruction:
+    def __init__(self, instr, offset, block, line):
+        self.raw = instr
+        self.is_ret = instr.asm.startswith('ret')
+        self.is_call = instr.asm.startswith('call') or instr.asm.startswith('bl')
+        self.offest = offset
+        self.block = block
+        self.line = line
+        self.inlined = None
+class Block:
+    def __init__(self, cfg_node, function, offset):
+        self.raw = cfg_node
+        self.offset = offset
+        self.next = None
+        self.is_tail_call = False
+        self.function = function
+        self.children = dict()
+        self.parents = dict()
+        self.instructions = []
+        self.calls = dict()
+        self.count = 0
+        self.cycles = 0
+        self.icount = 0
+        self.loops = frozenset()
+class Loop:
+    pass
+class Function:
+    def __init__(self, name):
+        self.name = name
+        self.rawname = name
+        self.shortname = name
+        self.longname = name
+        self.namesuffix = ''
+        self.cycles = 0
+        self.count = 0
+        self.samples_inc = 0
+        self.invocations = 0
+        self.instructions = []
+        self.blocks = dict()
+        self.files = dict()
+        self.inlineds = set()
+class InlinedFunction:
+    def __init__(self, name, parent):
+        self.name = name
+        self.rawname = name
+        self.longname = name
+        self.namesuffix = ''
+        self.parents = set([parent])
+        self.cycles = 0
+        self.count = 0
+        self.files = set()
+
+def add_line(f, line):
+    if line.file not in f.files:
+        f.files[line.file] = (line.number,line.number)
+    else:
+        f.files[line.file] = (
+            min(f.files[line.file][0], line.number),
+            max(f.files[line.file][1], line.number)
+        )
+
+_lineid = 0
+class Line:
+    def __init__(self, file, number):
+        global _lineid
+        self.file = file
+        self.number = number
+        self.text = None
+        self.html = None
+        self.id = _lineid
+        _lineid = _lineid + 1
+
+class File:
+    def __init__(self, path):
+        self.path = pathlib.Path(path)
+        self.lines = []
+        self.loaded = False
+        self.syntax = False
+        self.error = None
+        try:
+            with self.path.open() as f:
+                for line in f:
+                    cline = Line(self, len(self.lines)+1)
+                    cline.text = line[:-1]
+                    self.lines.append(cline)
+            self.loaded = True
+            self._p = subprocess.Popen([
+                '/usr/bin/ex', '-s', '-n', '-u', 'NONE', '-i', 'NONE', '-f',
+                '+syn on',
+                '+let html_no_progess = 1',
+                '+let html_use_css = 0',
+                '+set background=light',
+                '+colorscheme zellner',
+                '+run! syntax/2html.vim',
+                '+w! /dev/stdout',
+                '+qa!',
+                str(self.path),
+            ], stdout=subprocess.PIPE, stdin=subprocess.DEVNULL)
+        except OSError as e:
+            self.error = e.strerror
+        except Exception as e:
+            self.error = str(e)
+    def process(self):
+        if not self.loaded: return
+        try:
+            self._p.poll()
+            inBody = False
+            i = 0
+            for b in iter(self._p.stdout.readline, ""):
+                line = b.decode('utf-8')
+                if line.endswith('\n'):
+                    line = line[:-1]
+                if line.startswith('<font face="monospace">'):
+                    inBody = True
+                    continue
+                if not inBody: continue
+                if i >= len(self.lines): break
+                self.lines[i].html = line.replace("<u>","").replace("</u>","")
+                i = i + 1
+            self.syntax = True
+        except OSError as e:
+            self.error = e.strerror
+        except Exception as e:
+            self.error = str(e)
+        finally:
+            if self._p.poll() is None:
+                self._p.kill()
+
+    def get_line(self, number):
+        if number < 1: return None
+        while len(self.lines) <= number-1:
+            self.lines.append(Line(self, len(self.lines)+1))
+        return self.lines[number-1]
+
+loop_id = 0
+structure_to_node = dict()
+class Node:
+    def __init__(self, parent, structure_to_func, function, raw, loop=None):
+        self.raw = raw
+        self.parent = parent
+        self.function = function
+        self.is_loop = loop is not None
+        if loop is None:
+            self.id = 'func_' + str(raw.module.index) + "_" + str(raw.offset)
+            function.node = self
+            function.samples_inc = raw.samples
+        else:
+            global loop_id
+            self.id = 'loop_' + str(loop_id)
+            loop_id += 1
+            self.loop = loop
+        structure_to_node[raw] = self
+        self.nodes = []
+        self._convert_children(structure_to_func)
+    def _convert_children(self, structure_to_func):
+        for node in self.raw.nodes:
+            if issubclass(type(node), ProgramStructure.Loop):
+                self.nodes.append(Node(self, structure_to_func, self.function, node, node))
+            elif issubclass(type(node), ProgramStructure.Function):
+                self.nodes.append(Node(self, structure_to_func, structure_to_func[node], node))
+            else:
+                raise RuntimeError("Unknown node")
+    def process_callees(self):
+        self.callees = list(map(lambda x: structure_to_node[x] if x in
+            structure_to_node else None, self.raw.callees))
+        self.callsites = dict()
+        if not self.is_loop:
+            for k, v in self.raw.callsites.items():
+                caller = k[0].functions[v[0]]
+                self.callsites[(structure_to_node[caller], k[1])] = v[1]
+        for node in self.nodes: node.process_callees()
+
+class Processed:
+    def __init__(self, cfg_file, inst_csv, loop_csv, structure_file):
+        print("Info: parse {0}".format(cfg_file.name))
+        cfg = ControlFlowGraph(cfg_file)
+        print("Info: parse {0}".format(inst_csv.name))
+        instrs = InstructionsCsv(inst_csv)
+        print("Info: parse {0}".format(loop_csv.name))
+        loops = LoopsCsv(loop_csv)
+        print("Info: parse {0}".format(structure_file.name))
+        structure = ProgramStructure(structure_file)
+
+        all_functions = set()
+        to_demangle = set()
+        inlineds = dict()
+        node_to_block = dict()
+        files = dict()
+        function_files = set()
+        structure_to_func = dict()
+
+        def parse_line(line):
+            if line == '?:?': return None
+            fields = line.rsplit(':',1)
+            return (fields[0], int(fields[1]))
+
+        self.cycles = 0
+        self.count = 0
+        self.is_loop = False
+        self.callees = []
+        print("Info: syntax highlighting source code...")
+        for path, module in instrs.instructions.items():
+            for addr in module.keys():
+                instr = module[addr]
+                pline = parse_line(instr.line)
+                if pline is not None:
+                    if pline[0] not in files:
+                        files[pline[0]] = File(pline[0])
+        for file in files.values():
+            file.process()
+        print("Info: processing...")
+        for path, module in instrs.instructions.items():
+            cfg_module = cfg.modules[path] if path in cfg.modules else None
+            structure_module = structure.modules[path] if path in cfg.modules else None
+            if structure_module is None:
+                print("Warning: module", path, "not found", file=sys.stderr)
+                continue
+            for func in structure_module.functions.values():
+                to_demangle.add(func.name)
+                function = Function(func.name)
+                structure_to_func[func] = function
+                all_functions.add(function)
+                block = None
+                lastblock = None
+                inlined = None
+                for addr in range(func.offset, func.offset+func.length):
+                    if addr not in module: continue
+                    instr = module[addr]
+                    pline = parse_line(instr.line)
+                    if pline is not None:
+                        line = files[pline[0]].get_line(pline[1])
+                    else:
+                        line = None
+
+                    self.cycles += instr.cycles
+                    self.count += instr.count
+                    if block is None or cfg_module is None or instr.address in cfg_module.nodes:
+                        rawblock = None
+                        if cfg_module is not None and instr.address in cfg_module.nodes:
+                            rawblock = cfg_module.nodes[instr.address]
+                        else:
+                            rawblock = lastblock
+                        newblock = Block(
+                            rawblock,
+                            function,
+                            instr.address - func.offset,
+                        )
+                        if block is not None: block.next = newblock
+                        function.blocks[newblock.offset] = block = newblock
+                        node_to_block[block.raw] = block
+                        block.count = instr.count
+                    function.cycles += instr.cycles
+                    function.count += instr.count
+                    block.cycles += instr.cycles
+                    block.icount += instr.count
+                    pinstr = Instruction(instr, instr.address - func.offset, block, line)
+                    function.instructions.append(pinstr)
+                    block.instructions.append(pinstr)
+                    if line is not None and instr.inlined == instr.function:
+                        add_line(function, line)
+                    if instr.inlined == instr.function:
+                        continue
+                    if inlined is None or instr.inlined != inlined.name:
+                        if instr.inlined in inlineds:
+                            inlined = inlineds[instr.inlined]
+                        else:
+                            to_demangle.add(instr.inlined)
+                            inlineds[instr.inlined] = inlined = InlinedFunction(
+                                instr.inlined, function,
+                            )
+                        inlined.parents.add(function)
+                    pinstr.inlined = inlined
+                    function.inlineds.add(inlined)
+                    inlined.cycles += instr.cycles
+                    inlined.count += instr.count
+                    if line is not None:
+                        add_line(inlined, line)
+                for block in function.blocks.values():
+                    if block.raw is None: continue
+                    for child, count in block.raw.children.items():
+                        if child.module == block.raw.module \
+                                and child.first - func.offset in function.blocks \
+                                and not block.instructions[-1].is_call:
+                            cblock = function.blocks[child.first - func.offset]
+                            block.children[cblock] = count
+                            cblock.parents[block] = count
+                        elif block.instructions[-1].is_ret:
+                            pass
+                        else:
+                            block.calls[child] = count
+                            block.is_tail_call = not block.instructions[-1].is_call
+                            if not block.is_tail_call:
+                                cblock = block.next
+                                if cblock is not None:
+                                    block.children[cblock] = count
+                                    cblock.parents[block] = count
+        print("Info: demangling symbol names")
+        demang_noargs = dict()
+        demang_args = dict()
+        inp = ''
+        for s in to_demangle:
+            demang_noargs[s] = s
+            demang_args[s] = s
+            inp += s + '\n'
+
+        def demangle(args, res):
+            try:
+                with subprocess.Popen([
+                            '/usr/bin/env', 'c++filt'
+                        ] + args, stdout=subprocess.PIPE, stdin=subprocess.PIPE) as demang:
+                    try:
+                        out, err = demang.communicate(input=inp.encode(), timeout=15)
+                    except subprocess.TimeoutExpired:
+                        demang.kill()
+                        out, err = demang.communicate()
+                    out = out.decode()
+                    pos = 0
+                    for s in to_demangle:
+                        end = out.find('\n', pos)
+                        if end == -1: break
+                        res[s] = out[pos:end].strip()
+                        pos = end + 1
+            except Exception as e:
+                print("Wanrning: symbol name demangling failed: " + str(e), file=sys.stderr)
+                pass # oh well
+        demangle(['-p'], demang_noargs)
+        demangle([], demang_args)
+
+        def set_name(function):
+            if function.rawname in demang_noargs:
+                function.shortname = demang_noargs[function.rawname]
+            if function.rawname in demang_args:
+                function.longname = demang_args[function.rawname]
+                pos = function.longname.rfind('[clone ')
+                if pos != -1 and function.longname[-1] == ']':
+                    function.namesuffix = function.longname[pos+7:-1]
+
+        for function in inlineds.values(): set_name(function)
+        for function in all_functions: set_name(function)
+
+        function_names = set()
+        named_functions = dict()
+
+        def insert_function(function):
+            if function.name in function_names:
+                if function.name in named_functions:
+                    first = named_functions[function.name]
+                    if first.namesuffix != '' or function.namesuffix == '':
+                        if first.name == first.shortname and first.namesuffix != '':
+                            first.name = first.shortname + first.namesuffix
+                            function_names.remove(function.name)
+                        else:
+                            first.name = first.name + " (1)"
+                        del named_functions[function.name]
+                        insert_function(first)
+                if function.name == function.shortname and function.namesuffix != '':
+                    function.name = function.shortname + function.namesuffix
+                    insert_function(function)
+                    return
+                if function.name not in function_names:
+                    insert_function(function)
+                    return
+                i = 1
+                newname = function.name + " (" + str(i) + ")"
+                while newname in named_functions:
+                    i = i + 1
+                    newname = function.name + " (" + str(i) + ")"
+                function.name = newname
+            else:
+                function_names.add(function.name)
+            named_functions[function.name] = function
+
+        # Make function names unique
+        for function in all_functions:
+            function.name = function.shortname
+            insert_function(function)
+
+        print("Info: process functions")
+        for function in named_functions.values():
+            for block in function.blocks.values():
+                new_calls = dict()
+                for target, count in block.calls.items():
+                    target_block = node_to_block[target]
+                    new_calls[target_block] = count
+                    target_block.function.invocations += count
+                block.calls = new_calls
+
+        self.nodes = []
+        for node in structure.nodes:
+            self.nodes.append(Node(self, structure_to_func, structure_to_func[node], node))
+        for node in self.nodes: node.process_callees()
+
+        self.functions = named_functions
+        self.inlined = inlineds

--- a/src/gui/render.py
+++ b/src/gui/render.py
@@ -1,0 +1,878 @@
+import colorsys
+import graphviz
+import html
+import math
+import urllib.parse
+
+def _make_page(title, body):
+    return '\n'.join([
+        '<!DOCTYPE html>',
+        '<html>',
+        ' <head>',
+        '  <title>' + html.escape(title, quote=False) + '</title>',
+        '  <style>',
+        '.function-name { font-family: monospace; }',
+        '*[onclick] { cursor: pointer; }',
+        'body { background: #fff; }',
+        'body > h1 { display: inline; }',
+        'body > h3 { display: inline; }',
+        '.structure-svg { max-width: 100%; overflow-x: scroll; }',
+        '@media (width <= 100em) {',
+            '.main-area {  position: absolute; top: 18em; bottom: 0; left: 0; right: 0; overflow: scroll; }',
+            '.asm-svg { position: absolute; top: 0; bottom: 0; left: 0; right: 0; overflow: scroll; }',
+            '.asm-table { position: absolute; top: 0; bottom: 0; left: 0; right: 0; overflow: scroll; }',
+            '.code-listing { position: absolute; top: 0; bottom: 0; left: 0; right: 0; overflow: scroll; }',
+            '.show-if-medium { display: none; }',
+            '.tab-small { display: none; }',
+            '.tab-small[data-selected] { display: initial; }',
+        '}',
+        '@media (100em < width <= 150em) {',
+            '.main-area { position: absolute; top: 18em; bottom: 0; left: 0; right: 0; overflow: scroll; }',
+            '.asm-svg { position: absolute; top: 0; bottom: 0; left: 0; width: 50%; overflow: scroll; }',
+            '.asm-table { position: absolute; top: 0; bottom: 0; left: 50%; right: 0; overflow: scroll; border-left: black solid; border-right: black solid; box-sizing: border-box; }',
+            '.code-listing { position: absolute; top: 0; bottom: 0; left: 0; right: 0; overflow: scroll; }',
+            '.show-if-small { display: none; }',
+            '.tab-medium { display: none; }',
+            '.tab-medium[data-selected] { display: initial; }',
+            '.asm-svg svg { margin: 50%; }',
+            '.asm-table table { margin: 50% 1em; }',
+        '}',
+        '@media (width > 150em) {',
+            '.asm-svg { position: absolute; top: 15em; bottom: 0; left: 0; width: 30%; overflow: scroll; }',
+            '.asm-table { position: absolute; top: 15em; bottom: 0; left: 30%; right: 40%; overflow: scroll; border-left: black solid; border-right: black solid; box-sizing: border-box; }',
+            '.code-listing { position: absolute; top: 15em; bottom: 0; left: 60%; right: 0; overflow: scroll; }',
+            '.show-if-small { display: none; }',
+            '.show-if-medium { display: none; }',
+            '.asm-svg svg { margin: 50%; }',
+            '.asm-table table { margin: 50% 1em; }',
+            '.code-listing table { margin: 50% 1em; }',
+        '}',
+        '.tab-control { position: absolute; top: 15em; left: 0; right: 0; }',
+        '.button{',
+            'display: block;',
+            'float: left;',
+            'padding:5px 15px;',
+            'text-align:center;',
+            'margin:5px;',
+            'border-radius:5px;',
+            '-moz-border-radius:5px;',
+            '-webkit-border-radius:5px;',
+            'background-color:#428bca;',
+            'border-color:#357ebd;',
+            'border:1px solid;',
+            'color:#FFF;',
+            'text-decoration:none;',
+        '}',
+        'button:hover{',
+            'color:#FFF;',
+            'background-color:#357ebd;',
+            'border-color:#428bca;',
+        '}',
+        '.caller-list { position: absolute; top: 5em; height: 10em; left: 0; width: 50%; overflow: scroll; }',
+        '.loop-list { position: absolute; top: 5em; height: 10em; right: 0; width: 50%; overflow: scroll; }',
+
+        '.caller-list table { white-space: nowrap; border-collapse: collapse; }',
+        '.caller-list thead tr { position: sticky; top: 0.0em; border: white thick solid; background: white; }',
+        '.caller-list td { text-align: right; }',
+        '.caller-list th { text-align: right; padding-left: 1em; vertical-algin: bottom; }',
+        '.caller-list td:nth-child(1) { font-family: monospace; }',
+        '.caller-list td:nth-child(2) { font-family: monospace; }',
+
+        '.loop-list table { white-space: nowrap; border-collapse: collapse; }',
+        '.loop-list thead tr { position: sticky; top: 0.0em; border: white thick solid; background: white; }',
+        '.loop-list td { text-align: right; }',
+        '.loop-list th { text-align: right; padding-left: 1em; vertical-algin: bottom; }',
+        '.loop-list td:nth-child(1) { text-align: left; font-family: monospace; }',
+        '.loop-list th:nth-child(1) { text-align: left; }',
+
+        '.asm-svg h3 { position: sticky; left: 0.0em; top: 0.0em; border: white thick solid; background: white; }',
+
+        '.asm-table table { white-space: nowrap; border-collapse: collapse; }',
+        '.asm-table thead tr { position: sticky; top: 0.0em; border: white thick solid; background: white; }',
+        '.asm-table tr { text-align: right; }',
+        '.asm-table td:nth-child(1) { font-family: monospace; }',
+        '.asm-table td:nth-child(2) { font-family: monospace; text-align: left; }',
+        '.asm-table td:nth-child(7) { text-align: left; }',
+        '.asm-table th:nth-child(2) { text-align: left; }',
+        '.asm-table th:nth-child(7) { text-align: left; }',
+        '.asm-table .block-rest td:nth-child(1) { color: #999999; }',
+        '.asm-table .block-rest td:nth-child(6) { color: #999999; }',
+        '.asm-table .line-rest { color: #999999; }',
+
+        '.code-listing table { border-collapse: collapse; }',
+        '.code-listing h3 { position: sticky; left: 0.0em; top: 0.0em; border: white thick solid; background: white; white-space: nowrap; overflow-y: hidden; }',
+        '.code-listing td { text-align: right; }',
+        '.code-listing td:nth-child(4) { text-align: left; }',
+        '.code-listing pre { margin: 0 }',
+        '.code-listing .line-irrelevant { background: #eee; }',
+        '.code-listing .line-irrelevant td:nth-child(1) * { display: none; }',
+        '.code-listing .line-irrelevant td:nth-child(2) * { display: none; }',
+        '  </style>',
+        '  <script>',
+        'function smooth_scroll(container, node) {',
+        '  const crect = container.getBoundingClientRect();',
+        '  const brect = node.getBoundingClientRect();',
+        '  container.scrollBy({',
+        '    left: (brect.left - crect.left) + (brect.width - crect.width) / 2,',
+        '    top: (brect.top - crect.top) + (brect.height - crect.height) / 2,',
+        '    behavior: "smooth",',
+        '  });',
+        '}',
+        'function is_hidden(el) {',
+        '  return (el.offsetParent === null)',
+        '}',
+        'delay_select_block = null;',
+        'function select_block(id) {',
+        '  const containers = document.getElementsByClassName("asm-svg")',
+        '  if (containers.length != 1) return;',
+        '  const container = containers[0];',
+        '  const nodes = container.getElementsByClassName("cfg-n" + id.toString())',
+        '  if (nodes.length != 1) return;',
+        '  delay_select_block = null;',
+        '  if (is_hidden(container)) delay_select_block = id;',
+        '  else smooth_scroll(container, nodes[0]);',
+        '}',
+        'delay_select_asm = null;',
+        'function select_asm(id) {',
+        '  const containers = document.getElementsByClassName("asm-table")',
+        '  if (containers.length != 1) return;',
+        '  const container = containers[0];',
+        '  const nodes = container.querySelectorAll("a[name=\\"" + id.toString(16) + "\\"]")',
+        '  if (nodes.length != 1) return;',
+        '  delay_select_asm = null;',
+        '  if (is_hidden(container)) delay_select_asm = id;',
+        '  else smooth_scroll(container, nodes[0]);',
+        '}',
+        'delay_select_line = null;',
+        'function select_line(id) {',
+        '  const containers = document.getElementsByClassName("code-listing")',
+        '  if (containers.length != 1) return;',
+        '  const container = containers[0];',
+        '  const nodes = container.querySelectorAll(".line-" + id.toString() + "")',
+        '  if (nodes.length != 1) return;',
+        '  delay_select_line = null;',
+        '  if (is_hidden(container)) delay_select_line = id;',
+        '  else smooth_scroll(container, nodes[0]);',
+        '}',
+        'function select_tab(size, id) {',
+        '  const tabs = document.getElementsByClassName("tab-" + size);',
+        '  for (i = 0; i < tabs.length; i++) {',
+        '    tabs[i].removeAttribute("data-selected");',
+        '    if (tabs[i].getAttribute("data-tab-id") != id) continue;',
+        '    tabs[i].setAttribute("data-selected", "");',
+        '  }',
+        '  setTimeout(() => {',
+        '    if (delay_select_block) select_block(delay_select_block);',
+        '    if (delay_select_asm) select_asm(delay_select_asm);',
+        '    if (delay_select_line) select_line(delay_select_line);',
+        '  }, 0);'
+        '}',
+        '  </script>',
+        ' </head>',
+        ' <body>',
+        body,
+        ' </body>',
+        '</html>',
+    ])
+
+def hsv_to_html(h, s, v):
+    c = colorsys.hsv_to_rgb(h, s, v)
+    return '#{0:02x}{1:02x}{2:02x}'.format(
+        int(c[0] * 0xff),
+        int(c[1] * 0xff),
+        int(c[2] * 0xff),
+    )
+
+def _cpi_color(cycles, count):
+    if count == 0: return 'black'
+    cpi = cycles / count
+    return hsv_to_html(0.1, min(1, cpi * 2 / 10), min(1, cpi / 10))
+def _cycles_color(cycles, function_cycles):
+    if function_cycles == 0: return 'black'
+    cycles = cycles / function_cycles
+    return hsv_to_html(0.1, min(1, cycles * 2 * 10), min(1, cycles * 10))
+def _cover_color(cover):
+    return hsv_to_html(0.1, cover / 3, 1)
+
+
+# https://stackoverflow.com/a/25808207
+def safePath(url):
+    return ''.join(map(lambda ch: chr(ch) if ch in safePath.chars else '%%%02x' % ch, url.encode('utf-8')))[:128]
+safePath.chars = frozenset(map(lambda x: ord(x), '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz+-_ .(){}[]^&;@!'))
+
+class Renderer:
+    def __init__(self, processed):
+        self.processed = processed
+
+    def render_functions(self):
+        rows = sorted(self.processed.functions.values(), key=lambda x: -x.node.raw.cover)
+        rows = map(lambda x: ''.join([
+            '<tr>',
+            '<td>', '<a',
+            '' if self.function_filename(x) is None else ' href="' + urllib.parse.quote(self.function_filename(x)) + '"',
+            '>', x.name, '</a></td>',
+            '<td>', '{0:.1%}'.format(x.node.raw.cover), '</td>',
+            '<td>', '{0:.1%}'.format(x.cycles / self.processed.cycles), '</td>',
+            '<td>', str(x.invocations), '</td>',
+            '<td>', '-' if x.node.raw.cover == 0 else '{0:.2f}'.format(x.node.raw.ipc), '</td>',
+            '<td>', '-' if x.cycles == 0 else '{0:.2f}'.format(x.count / x.cycles), '</td>',
+            '</tr>'
+        ]), rows)
+        digraph = graphviz.Digraph('structure',
+            graph_attr={'ranksep':'0.2', 'splines': 'ortho', 'tooltip':'Dynamic program structure'},
+            node_attr={'fontsize':'9.0', 'width':'0', 'height':'0'},
+            edge_attr={'fontsize':'9.0', 'arrowsize':'0.5'},
+        )
+        self._render_structure_svg(digraph, None, self.processed)
+        svg = digraph.pipe('svg').decode('utf-8')
+        svg = svg[svg.find('<svg'):]
+        return _make_page('Functions list', '\n'.join([
+            '<h1>Structure</h1>',
+            '<p>Dynamic structure of the program showing all functions and',
+            'loops encountered during execution with more than 1% execution time. Rectangles represent',
+            'functions, ellipses represent loops. Arrows represent calls to ',
+            'functions, or invocations of loops.</p>',
+            '<div class="structure-svg">', svg, '</div>',
+            '<h1>All functions</h1>',
+            '<table>',
+            ' <thead><tr><th>Name</th><th>Cycles</th><th>Self cycles</th><th>Invocations</th><th>IPC</th><th>Self IPC</th></tr></thead>',
+            ' <tbody>', '\n'.join(rows), '</tbody>'
+            '</table>',
+        ]))
+
+    def _render_structure_svg(self, digraph, parent, structure, dotty=False, func=None):
+        def is_trivial(node):
+            return (len(node.nodes) > 0
+                and (len(node.nodes) <= 1 or node.nodes[1].raw.cover < 0.005)
+                and node.nodes[0].raw.cover >= 0.995
+                and not node.nodes[0].is_loop
+            )
+        func=func if structure.is_loop else structure
+        if parent is None:
+            if is_trivial(structure) and is_trivial(structure.nodes[0]):
+                self._render_structure_svg(digraph, None, structure.nodes[0], func=func)
+                return
+
+        with digraph.subgraph() as s:
+            s.attr(rank='same')
+            first = True
+            for node in structure.nodes:
+                if node.raw.cover < 0.01: continue
+                node_name = node.id
+                if node.is_loop:
+                    filename = self.function_filename(func.function)
+                    url = None if filename is None else '' + urllib.parse.quote(filename) + '#' + hex(node.raw.offset)[2:]
+                    s.node(
+                        node_name,
+                        label=''.join([
+                            '<',
+                            'Loop {0:.1f}&times;'.format(node.raw.iter_per_invoc),
+                            '<BR /><FONT POINT-SIZE="8.0" FACE="sans">',
+                            str(node.raw.invocations),
+                            '</FONT><BR /><FONT POINT-SIZE="8.0" FACE="sans">',
+                            '{0:.0%} (IPC {1:.2f})'.format(node.raw.cover, node.raw.ipc),
+                            '</FONT>>',
+                        ]),
+                        fillcolor=_cover_color(node.raw.cover),
+                        tooltip=('A loop in the function "{0}" that is executed {2} ' +
+                        'times with {3} iterations per execution on average. {1:.0%} of '+
+                        'execution time is spent in this loop and its ' +
+                        'children.').format(func.function.name, node.raw.cover,
+                            node.raw.invocations, node.raw.iter_per_invoc),
+                        style='filled',
+                        URL=url,
+                    )
+                else:
+                    filename = self.function_filename(node.function)
+                    url = None if filename is None else '' + urllib.parse.quote(filename)
+                    s.node(
+                        node_name,
+                        label=''.join([
+                            '<',
+                            '<FONT FACE="monospace">',
+                            node.function.name,
+                            '</FONT><BR /><FONT POINT-SIZE="8.0" FACE="sans">',
+                            str(node.raw.invocations),
+                            '</FONT><BR /><FONT POINT-SIZE="8.0" FACE="sans">',
+                            '{0:.0%} (IPC {1:.2f})'.format(node.raw.cover, node.raw.ipc),
+                            '</FONT>>',
+                        ]),
+                        fillcolor=_cover_color(node.raw.cover),
+                        shape='box',
+                        tooltip=('A function named "{0}" called {2} ' +
+                        'times. {1:.0%} of '+
+                        'execution time is spent in this function and its ' +
+                        'callees.').format(node.function.name, node.raw.cover,
+                            node.raw.invocations),
+                        style='filled',
+                        URL=url,
+                    )
+                if parent is not None:
+                    hide = not node.is_loop and node not in node.parent.callees
+                    digraph.edge(parent, node_name, **{
+                        'constraint':'true' if first else 'false',
+                        'style':'invis' if hide else '',
+                        'tooltip':'Loop entry' if node.is_loop else 'Function call',
+                    })
+                for callee in node.callees:
+                    if callee is None: continue
+                    if callee.raw.cover < 0.01: continue
+                    if callee in node.nodes: continue
+                    flat_nodes = set()
+                    def flatten(node):
+                        flat_nodes.add(node)
+                        for n in node.nodes:
+                            if n.is_loop and n.raw.cover < 0.01:
+                                flat_nodes.add(n)
+                                flatten(n)
+                    flatten(node)
+                    found = False
+                    for site in callee.raw.callsites.keys():
+                        for n in flat_nodes:
+                            if site[0] == callee.raw.module and site[1] in n.raw.blocks_exclusive:
+                                found = True
+                                break
+                        if found: break
+                    if not found: continue
+                    digraph.edge(node_name, callee.id, **{
+                        'constraint':'false',
+                        'tooltip':'Function call',
+                    })
+                first = False
+
+        for node in structure.nodes:
+            if node.raw.cover < 0.01: continue
+            node_name = node.id
+            self._render_structure_svg(digraph, node_name, node, func=func)
+
+    def _render_asm_svg(self, function, block_colors):
+        loop_colors = dict()
+        for block in function.blocks.values():
+            hue = len(block_colors) * 0.4314159
+            loop_colors[block.instructions[0].raw.address] =  hsv_to_html(hue, 0.1, 1.0)
+            block_colors[block] = hsv_to_html(hue, 0.2, 1.0)
+        def _render_asm_svg_recursive(self, cfg, root, function, node, block_colors):
+            for block in function.blocks.values():
+                if not block.instructions[0].raw.address in node.raw.blocks_exclusive: continue
+                lines = dict()
+                for i in block.instructions:
+                    if i.line is None: continue
+                    if i.line not in lines: lines[i.line] = 0
+                    lines[i.line] += max(1, i.raw.cycles)
+                line = None
+                for k, v in lines.items():
+                    if line is None or lines[k] > lines[line]:
+                        line = k
+                node_name = 'n' + str(block.offset)
+                cfg.node(
+                    node_name,
+                    label=''.join([
+                        '<',
+                        '<FONT FACE="monospace">',
+                        hex(block.instructions[0].raw.address)[2:],
+                        '</FONT><BR /><FONT POINT-SIZE="8.0" FACE="sans">',
+                        str(block.count),
+                        '</FONT><BR /><FONT POINT-SIZE="8.0" FACE="sans">',
+                        '-' if function.cycles == 0 else
+                        '0%' if block.cycles == 0 else
+                        '{0:.0%} (IPC {1:.2f})'.format(block.cycles / max(1, function.cycles), block.icount / max(1, block.cycles)),
+                        '</FONT>>',
+                    ]),
+                    fillcolor=block_colors[block],
+                    shape='box',
+                    style='filled',
+                    height=str(math.log(len(block.instructions)) / 3),
+                    URL='javascript:' + ('' if line is None else 'select_line({0})%3b'.format(line.id)) +  'select_asm({0})%3bselect_tab(%22small%22,%22asm%22)%3b'.format(block.instructions[0].raw.address),
+                    tooltip=('Block at hexadecimal offset {1} containing {0} '
+                        'instructions. The block executes {2} times and takes '
+                        '{3:.0%} of the function\'s own execution time.').format(
+                            len(block.instructions),
+                            hex(block.instructions[0].raw.address)[2:],
+                            block.count,
+                            block.cycles / max(1, function.cycles),
+                    ),
+                    **{'class':'cfg-'+node_name},
+                )
+                if block.offset == 0:
+                    root.edge('Entry', node_name, **{'tooltip':'Function entry','color':'#000066'})
+                if len(block.calls) > 0:
+                    call_node_name = node_name + '_callees'
+                    tooltip = 'Function call' + ('s' if len(block.calls) > 1 else '') + ' from preceeding block'
+                    label = '<<TABLE TITLE="' + tooltip + '" BORDER="0">'
+                    for child, count in block.calls.items():
+                        filename = self.function_filename(child.function)
+                        href = '' if filename is None else ' HREF="' + urllib.parse.quote(filename) + '"'
+                        label += ('<TR><TD BORDER="0"' + href +
+                            '><FONT FACE="monospace">' +
+                            html.escape(child.function.name) + "</FONT>")
+                        if len(block.calls) > 1:
+                            label += '</TD><TD>{0:.0%} ({1})'.format(count / max(1, float(block.count)),count)
+                        label += '</TD></TR>'
+                    label += '</TABLE>>'
+                    cfg.node(
+                        call_node_name,
+                        label=label,
+                        style='filled',
+                        fillcolor='white',
+                        shape='box',
+                        tooltip=tooltip,
+                    )
+                    root.edge(node_name, call_node_name, **{'tooltip':'Function call'})
+                    if block.is_tail_call:
+                        root.edge(call_node_name, 'Return', **{'tooltip':'Function return via tail call','color':'#660000'})
+                    else:
+                        for n in block.children.keys():
+                            root.edge(call_node_name, 'n' + str(n.offset))
+                elif block.instructions[-1].is_ret:
+                    root.edge(node_name, 'Return', **{'tooltip':'Function returns','color':'#660000'})
+                else:
+                    for child, count in block.children.items():
+                        is_backedge = node.is_loop and node.raw.offset == child.instructions[0].raw.address
+                        if len(block.children) > 1:
+                            percent = count / max(1, float(block.count))
+                            label = '{0:.0%} ({1})'.format(percent,count)
+                            tooltip = 'Block {0} was follwed by block {1} {2:.0%} of the time.'.format(
+                                        hex(block.instructions[0].raw.address)[2:],
+                                        hex(child.instructions[0].raw.address)[2:],
+                                        percent
+                                    )
+                        else:
+                            label = ''
+                            tooltip = 'Block {0} was always follwed by block {1}.'.format(
+                                        hex(block.instructions[0].raw.address)[2:],
+                                        hex(child.instructions[0].raw.address)[2:],
+                                    )
+                        if is_backedge:
+                            tooltip += ' This is a backedge of the loop.'
+                        if is_backedge:
+                            root.edge('n' + str(child.offset), node_name,
+                                    label=label, **{'penwidth':'2.0','dir':'back','tooltip':tooltip})
+                        else:
+                            root.edge(node_name, 'n' + str(child.offset),
+                                    label=label, **{'tooltip':tooltip})
+            for child in node.nodes:
+                if not child.is_loop: continue
+                cover = child.raw.cycles / max(1,child.raw.cycles,function.node.raw.cycles)
+                ipc = child.raw.ipc
+                with cfg.subgraph(name='cluster_' + child.id, body=[
+                        (
+                            'tooltip="A loop at offset {4} that executes {2} times with {0:.1f} '
+                            'iterations per execution on average. {1:.0%} of '
+                            'execution time of this function is spent in this '
+                            'loop and its callees."'
+                            'label=<'
+                            'Loop {0:.1f}&times;'
+                            '<BR /><FONT POINT-SIZE="8.0" FACE="sans">'
+                            '{2}'
+                            '</FONT><BR /><FONT POINT-SIZE="8.0" FACE="sans">'
+                            '{1:.0%} (IPC {3:.2f})'
+                            '</FONT>>'
+                        ).format(
+                            child.raw.iter_per_invoc,
+                            cover,
+                            child.raw.invocations,
+                            ipc,
+                            hex(child.raw.offset)[2:]
+                        ),
+                        'fillcolor="' + loop_colors[child.raw.offset] + '"',
+                        'shape=rounded',
+                        'style=filled']) as s:
+                    _render_asm_svg_recursive(self, s, root, function, child, block_colors)
+        cfg = graphviz.Digraph('cfg',
+            graph_attr={
+                'ranksep':'0.0',
+                'tooltip':'Graph showing the basic blocks in the function and how'
+                ' control flow passes between them. Loops and function calls are '
+                ' highlighted as well as the function entry and exit.',
+            },
+            node_attr={'fontsize':'9.0', 'width':'0', 'height':'0'},
+            edge_attr={'fontsize':'9.0', 'arrowsize':'0.5'},
+        )
+        cfg.node('Entry', tooltip='Function entry point')
+        cfg.node('Return', tooltip='Function exit point')
+        with cfg.subgraph() as s:
+            _render_asm_svg_recursive(self, s, cfg, function, function.node, block_colors)
+        result = cfg.pipe('svg').decode('utf-8')
+        result = result[result.find('<svg'):]
+        return result
+    def _render_asm_table(self, function, block_colors):
+        rows = function.instructions
+        first = rows[0].raw.address
+        def cpi(instr):
+            if instr.raw.count == 0: return '-'
+            return '{0:.2f}'.format(instr.raw.cycles / instr.raw.count)
+        def cpi_color(instr):
+            return _cpi_color(instr.raw.cycles, instr.raw.count)
+        def cycles(instr):
+            if function.cycles == 0: return '-'
+            return '{0:.1%}'.format(instr.raw.cycles / function.cycles)
+        def cycles_color(instr):
+            return _cycles_color(instr.raw.cycles, function.cycles)
+        def line_class(instr, prev_instr):
+            first = (
+                prev_instr is None
+                or prev_instr.block is not instr.block
+                or prev_instr.line is not instr.line
+            )
+            return 'line-first' if first else 'line-rest'
+        def print_asm(asm):
+            if asm.endswith('>') and '+0x' in asm[asm.rfind('<')+1:]:
+                asm = asm[:asm.rfind('<')]
+            return html.escape(asm, quote=False)
+        rows = map(lambda x: ''.join([
+            '<tr',
+            ' title="Offset in hexadecimal into program/library"',
+            ' class="', 'block-first' if x[0].block.instructions[0] is x[0] else 'block-rest', '"',
+            ' onclick="',
+            '  select_block(', str(x[0].block.offset), ');',
+            '  select_tab(\'small\', \'cfg\');',
+            '' if x[0].line is None else '  select_line(' + str(x[0].line.id) + ');',
+            ' "',
+            '>',
+            '<td',
+            ' style="background: ', block_colors[x[0].block] , ';"',
+            '>',
+                '<a name="' + hex(x[0].raw.address)[2:] + '">',
+                    hex(x[0].raw.address)[2:],
+                '</a>',
+            '</td>',
+            '<td title="Assembly code">', print_asm(x[0].raw.asm), '</td>',
+            '<td title="Average cycles per instruction, i.e. average execution time" style="color: ', cpi_color(x[0]), '">', cpi(x[0]), '</td>',
+            '<td title="Percentage of function\'s own exeuction time sepnt on this instruction" style="color: ', cycles_color(x[0]), '">', cycles(x[0]), '</td>',
+            '<td title="Total samples on this instruction. Small values (e.g. less than 10) should not be considered statistically significant">', str(x[0].raw.samples), '</td>',
+            '<td title="Number of times this instruction executed">', str(x[0].raw.count), '</td>',
+            '<td',
+            ' title="Source code line corresponding to this instruction according to the compiler"',
+            ' class="', line_class(x[0], x[1]), '"',
+            ' onclick="',
+            '  select_block(', str(x[0].block.offset), ');',
+            '  select_tab(\'small\', \'listing\');',
+            '  select_tab(\'medium\', \'listing\');',
+            '' if x[0].line is None else '  select_line(' + str(x[0].line.id) + ');',
+            '  event.stopPropagation();',
+            ' "',
+            '>',
+                '' if x[0].line is None else x[0].line.file.path.name + ' ' + str(x[0].line.number),
+                '' if x[0].inlined is None else ' ({0})'.format(x[0].inlined.name),
+            '</td>',
+            '</tr>'
+        ]), zip(rows, [None] + rows[0:-1]))
+        return '\n'.join([
+            '<table>',
+            ' <thead><tr>',
+            '   <th title="Offset in hexadecimal into program/library">Offset</th>',
+            '   <th title="Assembly code">ASM</th>',
+            '   <th title="Average cycles per instruction, i.e. average execution time">CPI</th>',
+            '   <th title="Percentage of function\'s own exeuction time sepnt on this instruction">Cycles</th>',
+            '   <th title="Total samples on this instruction. Small values (e.g. less than 10) should not be considered statistically significant">Samples</th>',
+            '   <th title="Number of times this instruction executed">Exeuctions</th>',
+            '   <th title="Source code line corresponding to this instruction according to the compiler">Line</th>',
+            ' </tr></thead>',
+            ' <tbody>', '\n'.join(rows), '</tbody>',
+            '</table>',
+        ])
+    def _render_caller_table(self, function):
+        rows = []
+        for caller, count in function.node.callsites.items():
+            func = caller[0].function
+            filename = self.function_filename(func)
+            href = '' if filename is None else ' href="' + urllib.parse.quote(filename) + '#' + hex(caller[1])[2:] + '"'
+            rows.append(''.join([
+                '<tr>',
+                '<td title="Name of calling function">',
+                '<a', href, '>', func.name, '</a>',
+                '</td>',
+                '<td title="Offset in hexadecimal of the block that calls this function">', hex(caller[1])[2:], '</td>',
+                '<td title="Number of times the call occurs">', str(count), '</td>',
+                '</tr>',
+            ]))
+        if len(rows) == 0:
+            return 'This function has no dynamic callers'
+        return '\n'.join([
+            '<table>',
+            ' <thead><tr>',
+            '   <th title="Name of calling function">Caller</th>',
+            '   <th title="Offset in hexadecimal of the block that calls this function">Block</th>',
+            '   <th title="Number of times the call occurs">Calls</th>',
+            ' </tr></thead>',
+            ' <tbody>', '\n'.join(rows), '</tbody>',
+            '</table>',
+        ])
+
+    def _render_loop_table(self, function, block_colors):
+        def recursive_rows(loop, depth = 0):
+            block = function.blocks[loop.raw.offset - function.node.raw.offset]
+            rows = [''.join([
+                '<tr',
+                ' onclick="',
+                '  select_block(', str(block.offset), ');',
+                '  select_asm(', str(loop.raw.offset), ');',
+                ' "',
+                '>',
+                '<td'
+                ' title="Offset in hexadecimal of the start of the loop"'
+                ' style="',
+                ' padding-left: ', str(depth), 'em;',
+                ' background: ', block_colors[block], ';',
+                '"',
+                '>', hex(loop.raw.offset)[2:], '</td>',
+                '<td title="Number of times loop is entered">', str(loop.raw.invocations), '</td>',
+                '<td title="Average number of times loop is entered per entry to this function">{0:.1f}</td>'.format(loop.raw.invocations / max(1, function.invocations)),
+                '<td title="Total number of iterations of this loop">', str(loop.raw.iterations), '</td>',
+                '<td title="Average number of iterations of this loop per loop entry">{0:.1f}</td>'.format(loop.raw.iter_per_invoc),
+                '<td title="Average instructions executed per cycle during this loop">{0:.2f}</td>'.format(loop.raw.ipc),
+                '<td title="Average instructions executed per iteration during this loop">{0:.1f}</td>'.format(loop.raw.inst_per_iter),
+                '</tr>',
+            ])]
+            for node in loop.nodes:
+                if node.is_loop:
+                    rows.extend(recursive_rows(node, depth + 1))
+            return rows
+        rows = []
+        for node in function.node.nodes:
+            if node.is_loop:
+                rows.extend(recursive_rows(node))
+        if len(rows) == 0:
+            return 'This function has no dynamic loops'
+        return '\n'.join([
+            '<table>',
+            ' <thead><tr>',
+            '   <th title="Offset in hexadecimal of the start of the loop">Loop</th>',
+            '   <th title="Number of times loop is entered">Invocations</th>',
+            '   <th title="Average number of times loop is entered per entry to this function">Invocations<br /> per call</th>',
+            '   <th title="Total number of iterations of this loop">Iterations</th>',
+            '   <th title="Average number of iterations of this loop per loop entry">Iterations per<br />invocation</th>',
+            '   <th title="Average instructions executed per cycle during this loop">IPC</th>',
+            '   <th title="Average instructions executed per iteration during this loop">Instructions per<br />iteration</th>',
+            ' </tr></thead>',
+            ' <tbody>', '\n'.join(rows), '</tbody>',
+            '</table>',
+        ])
+    def _render_code_listing(self, function, block_colors):
+        if len(function.files) == 0: return ''
+        files = dict()
+        for f, l in function.files.items():
+            files[f] = [(l[0], l[1])]
+            for inlined in function.inlineds:
+                for file, lrange in inlined.files.items():
+                    if file in files:
+                        files[file].append((lrange[0], lrange[1]))
+                    else:
+                        files[file] = [(lrange[0], lrange[1])]
+        def line_class(line, ranges):
+            for minline, maxline in ranges:
+                if line.number >= minline and line.number <= maxline:
+                    return 'line-relevant'
+            return 'line-irrelevant'
+        def line_block(lines):
+            blocks = dict()
+            for instruction in function.instructions:
+                if instruction.line is not line: continue
+                if instruction.block not in blocks:
+                    blocks[instruction.block] = 0
+                blocks[instruction.block] += instruction.raw.cycles + 1
+            block = None
+            m = 0
+            for b, c in blocks.items():
+                if c <= m: continue
+                m = c
+                block = b
+            return block
+        line_blocks = dict()
+        for file in files.keys():
+            last_block = None
+            empty_lines = []
+            for line in file.lines:
+                b = line_block(line)
+                line_blocks[line] = b
+                if line.text is not None and line.text.strip() == '':
+                    empty_lines.append(line)
+                else:
+                    if last_block is not None and last_block == b:
+                        for l in empty_lines:
+                            line_blocks[l] = b
+                    empty_lines = []
+                    last_block = None
+                if b is not None: last_block = b
+        def line_onclick(line):
+            m = None
+            cycles = -1
+            for instruction in function.instructions:
+                if instruction.line is not line: continue
+                if instruction.raw.cycles < cycles: continue
+                cycles = instruction.raw.cycles
+                m = instruction
+            block = line_blocks[line]
+            if m is None and block is None: return ''
+            if m is None:
+                m = block.instructions[0]
+            if block is None:
+                block = m.block
+            return 'onclick=\'select_block({0}); select_asm({1});select_tab("small", "cfg");select_tab("medium", "cfg-asm");\''.format(
+                block.offset,
+                m.raw.address,
+            )
+        def line_cpi(line):
+            cycles = 0
+            count = 0
+            static = 0
+            for instruction in function.instructions:
+                if instruction.line is not line: continue
+                static += 1
+                cycles += instruction.raw.cycles
+                count += instruction.raw.count
+            cpi = '-' if count == 0 else '{0:.2f}'.format(cycles / count)
+            return \
+                '<span style="color: {0}" title="Average CPI (cycles per instruction) of the {1} instruction(s) associated with this line.">{2}</span>'.format(
+                    _cpi_color(cycles, count),
+                    static,
+                    cpi,
+                );
+        def line_cover(line):
+            if function.cycles == 0: return '-'
+            cycles = 0
+            for instruction in function.instructions:
+                if instruction.line is not line: continue
+                cycles += instruction.raw.cycles
+            if cycles == 0: return '-'
+            return '<span style="color: {0}">{1:.1%}</span>'.format(
+                _cycles_color(cycles, function.cycles),
+                cycles / function.cycles,
+            )
+        def line_block_color(lines):
+            prev = lines[0]
+            line = lines[1]
+            succ = lines[2]
+            prev = None if prev is None else line_blocks[prev]
+            line = line_blocks[line]
+            succ = None if succ is None else line_blocks[succ]
+            if line is None: return ''
+            prev_same = prev is not None and block_colors[line] == block_colors[prev]
+            succ_same = succ is not None and block_colors[line] == block_colors[succ]
+            return (
+                'background: ' + block_colors[line] + '; border: 1px black solid;' +
+                ('' if not prev_same else 'border-top: initial;') +
+                ('' if not succ_same else 'border-bottom: initial;') +
+                ''
+            )
+        def line_text(line):
+            if line.html is not None: return '<pre>' + line.html + '</pre>'
+            if line.text is not None: return '<pre>' + html.escape(line.text, quote=False) + '</pre>'
+            if line.file.error is not None: return html.escape(line.file.error, quote=False)
+            return '(null)'
+
+        listings = map(lambda x: '\n'.join([
+            '<h3 title="' + html.escape(str(x[0].path), True) + '">', html.escape(str(x[0].path.name)), '</h3>\n',
+            '<table>',
+            ' <tbody>',
+            '\n'.join(map(lambda line: ''.join([
+                '<tr',
+                ' class="', line_class(line[1], x[1]), '"',
+                ' ', line_onclick(line[1]),
+                '>',
+                '<td title="Average cycles per instruction (execution time) for instructions associated with this line.">',
+                line_cpi(line[1]),
+                '</td>',
+                '<td title="Percentage of this function&apos;s execution time spent on instructions associated with this line.">',
+                line_cover(line[1]),
+                '</td>',
+                '<td',
+                '' if line_blocks[line[1]] is None else
+                    ' title="Most instructions associated with this line are in basic block {0}."'.format(
+                        hex(line_blocks[line[1]].instructions[0].raw.address)[2:]
+                    ),
+                ' style="', line_block_color(line), '"',
+                ' class="line-', str(line[1].id), '">',
+                str(line[1].number),
+                '</td>',
+                '<td>', line_text(line[1]), '</td>',
+                '</tr>',
+            ]), zip([None] + x[0].lines[0:-1], x[0].lines, x[0].lines[1:] + [None]))),
+            '</tbody>',
+            '</table>',
+        ]), files.items())
+        return '\n'.join(listings)
+
+
+    def render_function(self, function):
+        block_colors = dict()
+        dot = self._render_asm_svg(function, block_colors)
+        caller_table = self._render_caller_table(function)
+        loop_table = self._render_loop_table(function, block_colors)
+        table = self._render_asm_table(function, block_colors)
+        listing = self._render_code_listing(function, block_colors)
+        cycles = 0
+        i = function.instructions[0]
+
+        for instruction in function.instructions:
+            if instruction.raw.cycles > cycles:
+                cycles = instruction.raw.cycles
+                i = instruction
+        name = html.escape(function.name, quote=False)
+        return _make_page(name + ' - performance analysis', '\n'.join([
+            '<a class="button" href="index.html" style="float: right;">Function index</a>',
+            '<h1><span class="function-name">' + name + '</span> - performance analysis</h1>',
+            '' if function.name == function.longname else '<h3> - <span class="function-name">' + function.longname + '</span></h3>',
+            '<div class="header-area">',
+            '<div class="caller-list">',
+            caller_table,
+            '</div>',
+            '<div class="loop-list">',
+            loop_table,
+            '</div>',
+            '</div>',
+            '<div class="show-if-medium tab-control">',
+            '<a class="button" onclick=\'select_tab("small", "cfg");select_tab("medium", "cfg-asm");\' >CFG/ASM</a>',
+            '<a class="button" onclick=\'select_tab("small", "listing");select_tab("medium", "listing");\' >Source</a>',
+            '</div>',
+            '<div class="show-if-small tab-control">',
+            '<a class="button" onclick=\'select_tab("medium", "cfg-asm");select_tab("small", "cfg");\' >CFG</a>',
+            '<a class="button" onclick=\'select_tab("medium", "cfg-asm");select_tab("small", "asm");\' >ASM</a>',
+            '<a class="button" onclick=\'select_tab("medium", "listing");select_tab("small", "listing");\' >Source</a>',
+            '</div>',
+            '<div class="main-area">',
+            '<div class="tab-medium" data-selected data-tab-id="cfg-asm">',
+            '<div class="asm-svg tab-small" data-tab-id="cfg" data-selected>',
+            '<h3 title="Graph showing the basic blocks in the function and how ',
+            'control flow passes between them. Loops and function calls are ',
+            'highlighted as well as the function entry and exit.">Control flow graph</h3>',
+            dot,
+            '</div>',
+            '<div class="asm-table tab-small" data-tab-id="asm">',
+            table,
+            '</div>',
+            '</div>',
+            '<div data-tab-id="listing" class="tab-medium">',
+            '<div data-tab-id="listing" class="code-listing tab-small"'
+            + '">',
+            listing,
+            '</div>',
+            '</div>',
+            '</div>',
+            '<script>',
+                'var found = false;',
+                'if (window.location.hash.startsWith(\'#\')) {',
+                    'const els = document.querySelectorAll(\'.asm-table a[name="\' + window.location.hash.substr(1) + \'"]\');',
+                    'if (els.length == 1 && els[0].parentElement.parentElement.onclick) {',
+                        'setTimeout(() => {',
+                        'select_asm(parseInt(window.location.hash.substr(1), 16));',
+                        'els[0].parentElement.parentElement.onclick();',
+                        '}, 0);',
+                        'found = true;',
+                    '}',
+                '}',
+                'if (!found) {',
+                    'setTimeout(() => {',
+                    ('' if i.line is None else 'select_line(' + str(i.line.id) + ');'),
+                    'select_asm(' + str(i.raw.address) + ');',
+                    'select_block(' + str(i.block.offset) + ');',
+                    '}, 0);',
+                '}',
+            '</script>',
+        ]))
+
+    def function_filename(self, function):
+        if function.do_render:
+            return safePath(function.name) + ".html"
+        else: return None
+


### PR DESCRIPTION
This patch adds a new command `optiwise gui` which generates an HTML and JavaScript interface for viewing the output of `optiwise analyze` more easily. The output includes a list of functions and a nesting tree of the main functions and loops in the program. For each function it also includes a page to view that function's control flow graph, assembly code, and source code.

The other patch first adds a new `structure.yaml` output of `optiwise analyze` as a prerequisite of the GUI. This replaces the old `structure.txt` output, so note that consuming tools will need to be adjusted. The information in `structure.yaml` is a superset of `structure.txt` so the adjustment should be manageable. 

For example, this is a control flow graph of a function in the GUI:
![Screenshot of a function's control flow graph in optiwise gui.](https://www.cl.cam.ac.uk/~awc32/optiwise-cfg-example.svg)

And here is an example of the new `structure.yaml` output of `optiwise analyze`:
```yaml
modules:
 - module: 2
   path: '/usr/lib/x86_64-linux-gnu/ld-2.31.so'
 - module: 3
   path: '/home/ubuntu/optiwise/tests/bin.x86_64/recursion-loop'
 - module: 4
   path: '/usr/lib/x86_64-linux-gnu/libc-2.31.so'
nodes:
 - function: '(0x1100)'
   address: {module: 2, offset: 0x1100, length: 0x47}
   invocations: 1
   stats-inclusive: {ipc: 1.73, cover: 1.000, cycles: 3649057871, samples: 992}
   blocks-exclusive: [0x1100, 0x1108, 0x113a]
   callers: []
   callees: [{module: 2, offset: 0x11c20}, {module: 2, offset: 0x1df0}, {module: 3, offset: 0x1130}]
   nodes:
    - function: '_start'
      address: {module: 3, offset: 0x1130, length: 0x2f}
      invocations: 1
      stats-inclusive: {ipc: 1.73, cover: 1.000, cycles: 3648744292, samples: 984}
      blocks-exclusive: [0x1130]
      callers: [{function: {module: 2, offset: 0x1100}, sites: [{offset: 0x113a, count: 1}]}]
      callees: [{module: 4, offset: 0x23f90}]
      nodes:
       - function: '__libc_start_main'
         address: {module: 4, offset: 0x23f90, length: 0x1e3}
         invocations: 1
         stats-inclusive: {ipc: 1.73, cover: 1.000, cycles: 3648744292, samples: 984}
         blocks-exclusive: [0x23f90, 0x23fd0, 0x23fdb, 0x23fe4, 0x23ff6, 0x23ffb, 0x24010, 0x24025, 0x2402d, 0x24037, 0x2403f, 0x24083]
         callers: [{function: {module: 3, offset: 0x1130}, sites: [{offset: 0x1130, count: 1}]}]
         callees: [{module: 3, offset: 0x1320}, {module: 3, offset: 0x1080}, {module: 4, offset: 0x42c80}, {module: 4, offset: 0x46a40}, {module: 4, offset: 0x46de0}]
         nodes:
          - function: 'main'
            address: {module: 3, offset: 0x1080, length: 0xa3}
            invocations: 1
            stats-inclusive: {ipc: 1.73, cover: 1.000, cycles: 3648744292, samples: 984}
            blocks-exclusive: [0x1080, 0x1090, 0x10a0, 0x10c5, 0x10cf, 0x10f7]
            callers: [{function: {module: 4, offset: 0x23f90}, sites: [{offset: 0x2403f, count: 1}]}]
            callees: [{module: 3, offset: 0x1220}, {module: 3, offset: 0x1070}]
            nodes:
             # skipped intermediate calls and loops
             - function: 'rec_loop_qsort'
               address: {module: 3, offset: 0x1220, length: 0xf9}
               invocations: 10000001
               stats-inclusive: {ipc: 1.74, cover: 0.987, cycles: 3601305866, samples: 931}
               blocks-exclusive: [0x1220, 0x123d, 0x1307]
               callers: [{function: {module: 3, offset: 0x1220}, sites: [{offset: 0x12e0, count: 10000000}]}, {function: {module: 3, offset: 0x1080}, sites: [{offset: 0x10c5, count: 1}]}]
               callees: [{module: 3, offset: 0x1220}]
               nodes:
                - loop: 0x1254
                  back-edges: [0x12f4]
                  invocations: 5000560
                  stats: {iterations: 10000000, iter-per-invoc: 2.0}
                  stats-inclusive: {ipc: 1.73, cover: 0.956, cycles: 3489041787, samples: 904, cyc-per-iter: 348.9, inst-per-iter: 602.5}
                  stats-exclusive: {ipc: 22.26, cover: 0.040, cycles: 145483997, samples: 36, cyc-per-iter: 14.5, inst-per-iter: 323.9}
                  blocks-exclusive: [0x1254, 0x12e0, 0x12f4]
                  blocks-inclusive: [0x1254, 0x1270, 0x127b, 0x1280, 0x1285, 0x12a3, 0x12a8, 0x12b0, 0x12b5, 0x12c6, 0x12cb, 0x12ce, 0x12e0, 0x12f4]
                  callees: [{module: 3, offset: 0x1220}]
...
```