### PR TITLE
Improve path handling

### DIFF
--- a/scripts/share/optiwise/bin/optiwise-run
+++ b/scripts/share/optiwise/bin/optiwise-run
@@ -34,6 +34,9 @@ Options:
   -i, --stdin   Redirect stdin for the profiled program to be the specified file.
   -o, --stdout  Redirect stdout for the profiled program to be the specified file.
   -e, --stderr  Redirect stderr for the profiled program to be the specified file.
+  -s, --skip    Skip a command e.g. '--skip count' would cause 'optiwise run'
+                not to execute 'optiwise count'. This allows reusing a previous
+                result. Can be specified multiple times to skip several commands.
 EOF
       exit 0
       ;;
@@ -53,6 +56,19 @@ EOF
     --stdout=*) stdout="--stdout=${1#--*=}";;
     -e|--stderr) shift; stderr="--stderr=$1";;
     --stderr=*) stderr="--stderr=${1#--*=}";;
+    -s|--skip)
+      shift
+      opt="$1"
+      shift
+      set -- "--skip=$opt" "$@"
+      continue
+      ;;
+    --skip=check) skip_check="$1" ;;
+    --skip=sample) skip_sample="$1" ;;
+    --skip=disassemble) skip_disassemble="$1" ;;
+    --skip=count) skip_count="$1" ;;
+    --skip=analyze) skip_analyze="$1" ;;
+    --skip=gui) skip_gui="$1" ;;
     --) shift; break;;
     -[^-]?*)
       opt="$1"
@@ -91,50 +107,63 @@ if [ ! -d "$result_dir" ]; then
   mkdir -p "$result_dir" || exit $?
 fi
 
-if [ "${flag_verbose-}" ]; then
-  echo "$share_bin_dir/optiwise-check" ${flag_verbose-} ${objdump-} ${flag_gui-} -- "$@"
+if [ -z "${skip_check-}" ]; then
+  if [ "${flag_verbose-}" ]; then
+    echo "$share_bin_dir/optiwise-check" ${flag_verbose-} ${objdump-} ${flag_gui-} -- "$@"
+  fi
+
+  "$share_bin_dir/optiwise-check" ${flag_verbose-} ${objdump-} ${flag_gui-} -- "$@" || exit $?
 fi
 
-"$share_bin_dir/optiwise-check" ${flag_verbose-} ${objdump-} ${flag_gui-} -- "$@" || exit $?
+if [ -z "${skip_sample-}" ]; then
+  if [ "${flag_verbose-}" ]; then
+    echo "$share_bin_dir/optiwise-sample" \
+      ${flag_verbose-} --name="$name" \
+      ${frequency-} ${stdin-} ${stdout-} ${stderr-} \
+      -- "$@"
+  fi
 
-if [ "${flag_verbose-}" ]; then
-  echo "$share_bin_dir/optiwise-sample" \
+  "$share_bin_dir/optiwise-sample" \
     ${flag_verbose-} --name="$name" \
     ${frequency-} ${stdin-} ${stdout-} ${stderr-} \
-    -- "$@"
+    -- "$@" || exit $?
 fi
 
-"$share_bin_dir/optiwise-sample" \
-  ${flag_verbose-} --name="$name" \
-  ${frequency-} ${stdin-} ${stdout-} ${stderr-} \
-  -- "$@" || exit $?
+if [ -z "${skip_disassemble-}" ]; then
+  if [ "${flag_verbose-}" ]; then
+    echo "$share_bin_dir/optiwise-disassemble" \
+      ${flag_verbose-} ${objdump-} --name="$name"
+  fi
 
-if [ "${flag_verbose-}" ]; then
-  echo "$share_bin_dir/optiwise-disassemble" \
-    ${flag_verbose-} ${objdump-} --name="$name"
+  "$share_bin_dir/optiwise-disassemble" \
+    ${flag_verbose-} ${objdump-} --name="$name" || exit $?
 fi
 
-"$share_bin_dir/optiwise-disassemble" \
-  ${flag_verbose-} ${objdump-} --name="$name" || exit $?
+if [ -z "${skip_count-}" ]; then
+  if [ "${flag_verbose-}" ]; then
+    echo "$share_bin_dir/optiwise-count" \
+      ${flag_verbose-} --name="$name" \
+      ${stdin-} ${stdout-} ${stderr-} \
+      -- "$@"
+  fi
 
-if [ "${flag_verbose-}" ]; then
-  echo "$share_bin_dir/optiwise-count" \
+  "$share_bin_dir/optiwise-count" \
     ${flag_verbose-} --name="$name" \
     ${stdin-} ${stdout-} ${stderr-} \
-    -- "$@"
+    -- "$@" || exit $?
 fi
 
-"$share_bin_dir/optiwise-count" \
-  ${flag_verbose-} --name="$name" \
-  ${stdin-} ${stdout-} ${stderr-} \
-  -- "$@" || exit $?
+if [ -z "${skip_analyze-}" ]; then
+  if [ "${flag_verbose-}" ]; then
+    echo "$share_bin_dir/optiwise-analyze" \
+      ${flag_verbose-} --name="$name"
+  fi
 
-if [ "${flag_verbose-}" ]; then
-  echo "$share_bin_dir/optiwise-analyze" \
+  "$share_bin_dir/optiwise-analyze" \
     ${flag_verbose-} --name="$name"
 fi
 
-if [ "${flag_gui-}" ]; then
+if [ "${flag_gui-}" ] && [ -z "${skip_gui-}" ]; then
   if [ "${flag_verbose-}" ]; then
     echo "$share_bin_dir/optiwise-gui" \
       ${flag_verbose-} --name="$name"

--- a/src/analyzer/Makefile
+++ b/src/analyzer/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS = -std=c++11 -O3 -Wall -g
+CXXFLAGS = -std=c++14 -O3 -Wall -g
 
 ifndef SERIAL
 OMP = -fopenmp

--- a/src/analyzer/io.hpp
+++ b/src/analyzer/io.hpp
@@ -15,6 +15,8 @@ public:
     const char* what() const noexcept override;
 };
 
+void report_module_problems();
+
 void read_perf_result(
         const char* perf_result_path,
         objdump_table& objdump_result,

--- a/src/analyzer/loop_profiler.cpp
+++ b/src/analyzer/loop_profiler.cpp
@@ -64,7 +64,7 @@ int inner_main(int argc, char **argv) {
         return 1;
     }
 
-    module_add_or_find("<none>");
+    module_add_or_find("<none>", module_add_or_find_role::none);
 
     /* read the instruction name from objdump output */
     objdump_table objdump_result;
@@ -97,6 +97,8 @@ int inner_main(int argc, char **argv) {
     func_sample func_sample_table;
     cout << "Info: Reading perf result from " << argv[1] << endl;
     read_perf_result(argv[1], objdump_result, profiling_result, func_sample_table);
+
+    report_module_problems();
 
     cout << "Info: Compute function statistics..." << endl;
     compute_function_statistics(functions, cfg);

--- a/src/analyzer/support.hpp
+++ b/src/analyzer/support.hpp
@@ -16,14 +16,31 @@
 using namespace std;
 
 struct app_module {
-    string path;
+    set<string> paths;
     map<uint64_t, pair<uint64_t, uint64_t>> file_offset_to_vaddr;
+    bool have_disassemble = false;
+    bool have_count = false;
+    bool have_sample = false;
+    uint64_t samples = 0;
+    uint64_t counts = 0;
+
+    app_module(string path) {
+        paths.insert(path);
+    }
+    const string &path() const { return *paths.begin(); }
 };
 
 typedef vector<app_module>::size_type app_module_id;
 typedef pair<app_module_id, uint64_t> address;
 
-app_module_id module_add_or_find(const string &path);
+enum class module_add_or_find_role {
+    none,
+    disassemble,
+    count,
+    sample,
+};
+app_module_id module_add_or_find(
+        const string &path, module_add_or_find_role role);
 app_module &module_lookup(app_module_id id);
 
 struct loop;


### PR DESCRIPTION
These patches are aiming to support advances uses of optiwise. In particular, it can be useful to reuse a result (particularly for `optiwise disassemble`) if the underlying binary has not changed. These patches add a `--skip` flag to `optiwise run` to enable a result to be reused, and also cause the analyzer to match filenames rather than full paths for modules if an exact match is not found.