### PR TITLE
Fixes before 1.0

### DIFF
--- a/scripts/share/optiwise/bin/optiwise-check
+++ b/scripts/share/optiwise/bin/optiwise-check
@@ -8,6 +8,7 @@ share_dir="$(realpath "$share_bin_dir/..")"
 dynamorio_dir="$share_dir/dynamorio"
 result_dir=optiwise_result
 objdump=objdump
+perf_event="cpu-cycles:uP"
 
 while :; do
   case "${1-}" in
@@ -30,6 +31,9 @@ Options:
   -g, --gui    Check if 'optiwise gui' is likely to succeed.
   -E, --objdump=<binary>
                Override the path/name of the 'objdump' utility.
+  --perf-event=<event>
+               Override the '-e/--event' argument to perf record. Sometimes
+               necessary as a workaround for unusual PMUs.
 EOF
       exit 0
       ;;
@@ -41,6 +45,8 @@ EOF
     -g|--gui) flag_gui="$1";;
     -E|--objdump) shift; objdump="$1";;
     --objdump=*) objdump="${1#--*=}";;
+    --perf-event) shift; perf_event="$1";;
+    --perf-event=*) perf_event="${1#--*=}";;
     --) shift; break;;
     -?*)
       cat >&2 <<EOF
@@ -96,16 +102,16 @@ Error: The installed version of perf does not match your kernel version.
        may help, or otherwise updating perf and/or the kernel to match.
 EOF
     any_error=1
-  elif ! perf record -e 'cpu-cycles:uP' -g -o /dev/null -- true > /dev/null 2> /dev/null; then
+  elif ! perf record -e "$perf_event" -g -o /dev/null -- true > /dev/null 2> /dev/null; then
     cat >&2 << EOF
 Error: perf record does not seem to work.
 
        For example, running:
-         perf record -e 'cpu-cycles:uP' -g -o /dev/null -- true
+         perf record -e '$perf_event' -g -o /dev/null -- true
        returns an error and prints:
 
 EOF
-    perf record -e 'cpu-cycles:uP' -g -o /dev/null -- true > /dev/null
+    perf record -e "$perf_event" -g -o /dev/null -- true > /dev/null
     printf "\n\n" >&2
     any_error=1
   elif [ -z "${flag_quiet+1}" ]; then

--- a/scripts/share/optiwise/bin/optiwise-run
+++ b/scripts/share/optiwise/bin/optiwise-run
@@ -31,6 +31,9 @@ Options:
   -f, --frequency
                 Sets sampling frequency to specified value in Hz.
   -E, --objdump Override the name of the 'objdump' utility.
+  --perf-event=<event>
+                Override the '-e/--event' argument to perf record. Sometimes
+                necessary as a workaround for unusual PMUs.
   -i, --stdin   Redirect stdin for the profiled program to be the specified file.
   -o, --stdout  Redirect stdout for the profiled program to be the specified file.
   -e, --stderr  Redirect stderr for the profiled program to be the specified file.
@@ -50,6 +53,8 @@ EOF
     --frequency=*) frequency="--frequency=${1#--*=}";;
     -E|--objdump) shift; objdump="--objdump=$1";;
     --objdump=*) objdump="--objdump=${1#--*=}";;
+    --perf-event) shift; perf_event="--perf-event=$1";;
+    --perf-event=*) perf_event="--perf-event=${1#--*=}";;
     -i|--stdin) shift; stdin="--stdin=$1";;
     --stdin=*) stdin="--stdin=${1#--*=}";;
     -o|--stdout) shift; stdout="--stdout=$1";;
@@ -109,23 +114,23 @@ fi
 
 if [ -z "${skip_check-}" ]; then
   if [ "${flag_verbose-}" ]; then
-    echo "$share_bin_dir/optiwise-check" ${flag_verbose-} ${objdump-} ${flag_gui-} -- "$@"
+    echo "$share_bin_dir/optiwise-check" ${flag_verbose-} ${objdump-} ${perf_event-} ${flag_gui-} -- "$@"
   fi
 
-  "$share_bin_dir/optiwise-check" ${flag_verbose-} ${objdump-} ${flag_gui-} -- "$@" || exit $?
+  "$share_bin_dir/optiwise-check" ${flag_verbose-} ${objdump-} ${perf_event-} ${flag_gui-} -- "$@" || exit $?
 fi
 
 if [ -z "${skip_sample-}" ]; then
   if [ "${flag_verbose-}" ]; then
     echo "$share_bin_dir/optiwise-sample" \
       ${flag_verbose-} --name="$name" \
-      ${frequency-} ${stdin-} ${stdout-} ${stderr-} \
+      ${frequency-} ${perf_event-} ${stdin-} ${stdout-} ${stderr-} \
       -- "$@"
   fi
 
   "$share_bin_dir/optiwise-sample" \
     ${flag_verbose-} --name="$name" \
-    ${frequency-} ${stdin-} ${stdout-} ${stderr-} \
+    ${frequency-} ${perf_event-} ${stdin-} ${stdout-} ${stderr-} \
     -- "$@" || exit $?
 fi
 

--- a/scripts/share/optiwise/bin/optiwise-sample
+++ b/scripts/share/optiwise/bin/optiwise-sample
@@ -7,6 +7,7 @@ result_dir=optiwise_result
 frequency=1000
 perf_opts=0
 name=result
+perf_event=cpu-cycles:uP
 
 # A note on parsing strategy: we move any --perf-opt options to the end of the
 # argument list, noting how many there are in $perf_opts. Then we rotate these
@@ -37,6 +38,9 @@ Options:
   -i, --stdin   Redirect stdin for the sampled program to be the specified file.
   -o, --stdout  Redirect stdout for the sampled program to be the specified file.
   -e, --stderr  Redirect stderr for the sampled program to be the specified file.
+  --perf-event=<event>
+                Override the '-e/--event' argument to perf record. Sometimes
+                necessary as a workaround for unusual PMUs.
   -p, --perf-opt=<option>
                 Pass option(s) to 'perf record' directly. Can be specified
                 multiple times.
@@ -58,6 +62,8 @@ EOF
     --stdout=*) stdout="${1#--*=}";;
     -e|--stderr) shift; stderr="$1";;
     --stderr=*) stderr="${1#--*=}";;
+    --perf-event) shift; perf_event="$1";;
+    --perf-event=*) perf_event="${1#--*=}";;
     -p|--perf-opt)
       perf_opts=$(($perf_opts+1))
       shift
@@ -153,7 +159,7 @@ if [ "${flag_verbose-}" ]; then
     ${flag_verbose-} \
     -o "$result_dir/sample/$name_sample" \
     -g -i \
-    -e 'cpu-cycles:uP' \
+    -e \'"$perf_event"\' \
     -F "$frequency" \
     --buildid-all \
     "$@"
@@ -162,7 +168,7 @@ exec perf --buildid-dir "$(realpath "$result_dir/binaries")" record \
   ${flag_verbose-} \
   -o "$result_dir/sample/$name_sample" \
   -g -i \
-  -e 'cpu-cycles:uP' \
+  -e "$perf_event" \
   -F "$frequency" \
   --buildid-all \
   "$@"

--- a/src/gui/processor.py
+++ b/src/gui/processor.py
@@ -331,9 +331,25 @@ class Processed:
         demangle(['-p'], demang_noargs)
         demangle([], demang_args)
 
+        def remove_template(name):
+            if name[-1] != '>': return name
+            level = 0
+            i = -1
+            for c in reversed(name):
+                if c == '>': level += 1
+                elif c == '<': level -= 1
+                if level == 0:
+                    return name[:i]
+                i -= 1
+            return name
+
         def set_name(function):
             if function.rawname in demang_noargs:
                 function.shortname = demang_noargs[function.rawname]
+                if len(function.shortname) > 48:
+                    function.shortname = remove_template(function.shortname)
+                if len(function.shortname) > 48:
+                    function.shortname = '...' + function.shortname[-45:]
             if function.rawname in demang_args:
                 function.longname = demang_args[function.rawname]
                 pos = function.longname.rfind('[clone ')

--- a/src/gui/render.py
+++ b/src/gui/render.py
@@ -9,6 +9,7 @@ def _make_page(title, body):
         '<!DOCTYPE html>',
         '<html>',
         ' <head>',
+        '  <meta charset="utf-8">',
         '  <title>' + html.escape(title, quote=False) + '</title>',
         '  <style>',
         '.function-name { font-family: monospace; }',
@@ -197,7 +198,15 @@ def _cover_color(cover):
 
 # https://stackoverflow.com/a/25808207
 def safePath(url):
-    return ''.join(map(lambda ch: chr(ch) if ch in safePath.chars else '%%%02x' % ch, url.encode('utf-8')))[:128]
+    url = url.replace('::', '.')
+    return ''.join(map(lambda ch:
+        chr(ch) if ch in safePath.chars
+        else '[' if ch == ord('<')
+        else ']' if ch == ord('>')
+        else '.' if ch == ord(':')
+        else '.' if ch == ord(',')
+        else '%%%02x' % ch, url.encode('utf-8')
+    ))[:128]
 safePath.chars = frozenset(map(lambda x: ord(x), '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz+-_ .(){}[]^&;@!'))
 
 class Renderer:
@@ -290,7 +299,7 @@ class Renderer:
                         label=''.join([
                             '<',
                             '<FONT FACE="monospace">',
-                            node.function.name,
+                            html.escape(node.function.name),
                             '</FONT><BR /><FONT POINT-SIZE="8.0" FACE="sans">',
                             str(node.raw.invocations),
                             '</FONT><BR /><FONT POINT-SIZE="8.0" FACE="sans">',


### PR DESCRIPTION
A few fixes to be added before the v1.0 release.

1. Adds a `--perf-event` flag to allow the user to override the `-e` parameter to `perf record`, which is sometimes necessary to work around compatibility issues.
2. Makes the function name handling in `optiwise gui` better when using C++ demangled names, aiming to use short but recognisable names in the GUI rather than long full demangled names which are hard to read.
3. Fixes the 'longjmp' detection in the DynamoRIO client to avoid underflowing the stack in the event that we repeatedly trigger the `handle_longjmp` function as happens in cases of e.g. coroutines.