### PR TITLE
Fix overlapping blocks bug in 'optiwise count'

### DIFF
--- a/src/dyclient/count.cpp
+++ b/src/dyclient/count.cpp
@@ -405,7 +405,7 @@ static void event_exit(void) {
         if (address.first != 0 || address.second != 0)
             executed_modules.insert(address.first);
         auto next = std::next(itr);
-        if (address.first == next->first.first && block.end_addr > next->first.second) { // blocks overlap
+        if (address.first == next->first.first && block.end_addr >= next->first.second) { // blocks overlap
             if (block.end_addr != next->second.end_addr) { // partial overlap!
                 for (auto &itr_child : block.child) {
                     if (itr_child.first.first == address.first &&


### PR DESCRIPTION
It was possible for the output of `optiwise count` to contain overlapping basic blocks due to a slightly buggy check in the overlap calculation. This occurred whenever a block overlapped a 1 instruction block, due to the `end_addr` field pointing to the last instruction rather than just past it.